### PR TITLE
✨ [FEAT] 게임 채점 엔드포인트 적용

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+SECRET_KEY=mysecretkkkkkkkeeyyeyyyyeyeyeyeyeyeyeyeyeey
+SECRET_KEY_AUTH=myauauauauthththkkkkkkkeeyyeyeyeyeey
+DB_HOST=192.168.82.76
+DB_USER=codegrounduser
+DB_PASSWORD=team_aksdbdlsfur
+DB_NAME=codegrounddb
+ONLINE_JUDGE_HOST_ENDPOINT=http://localhost:8000/execute
+ENV=DEV

--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     DB_PASSWORD: str = os.environ.get("DB_PASSWORD", "")
     DB_NAME: str = os.environ.get("DB_NAME", "")
     DB_URL: str = f"postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:5432/{DB_NAME}"
+    ONLINE_JUDGE_HOST_ENDPOINT: str = os.environ.get("ONLINE_JUDGE_HOST_ENDPOINT", "")
 
 
 settings = Settings()

--- a/src/app/domain/game/__init__.py
+++ b/src/app/domain/game/__init__.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+from .router import submit_controller
+
+router = APIRouter()
+router.include_router(submit_controller.router, prefix="/game", tags=["game"])

--- a/src/app/domain/game/router/submit_controller.py
+++ b/src/app/domain/game/router/submit_controller.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from src.app.domain.game.schemas import game_schemas as schemas
+from src.app.domain.game.service import game_service as service
+
+router = APIRouter()
+
+@router.post("/submit", response_model=schemas.SubmitResponse)
+async def submit_code(request: schemas.SubmitRequest):
+    result = await service.evaluate_code(request.language, request.code)
+    return schemas.SubmitResponse(**result)

--- a/src/app/domain/game/schemas/game_schemas.py
+++ b/src/app/domain/game/schemas/game_schemas.py
@@ -1,0 +1,11 @@
+
+from typing import List, Dict, Any
+from pydantic import BaseModel
+
+class SubmitRequest(BaseModel):
+    language: str
+    code: str
+
+class SubmitResponse(BaseModel):
+    result: str
+    detail: List[Dict[str, Any]] | None = None

--- a/src/app/domain/game/service/game_service.py
+++ b/src/app/domain/game/service/game_service.py
@@ -1,0 +1,24 @@
+import httpx
+from fastapi import HTTPException
+from src.app.config.config import settings
+
+async def evaluate_code(language: str, code: str):
+    payload = {
+        "language": language,
+        "code": code,
+        "stdins": [],
+        "timeLimit": 30000,
+        "memoryLimit": 256,
+        "token": None,
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(settings.ONLINE_JUDGE_HOST_ENDPOINT, json=payload)
+            response.raise_for_status()
+            results = response.json()
+        except httpx.HTTPStatusError as e:
+            raise HTTPException(status_code=e.response.status_code, detail="Judge request failed")
+        except httpx.HTTPError:
+            raise HTTPException(status_code=500, detail="Judge service unreachable")
+    success = all(res.get("exitCode") == 0 for res in results)
+    return {"result": "correct" if success else "wrong", "detail": results}

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -9,6 +9,7 @@ from src.app.domain.auth import router as auth_router
 from src.app.domain.webrtc import router as webrtc_router
 from src.app.domain.match import router as match_router
 from src.app.domain.user import router as user_router
+from src.app.domain.game import router as game_router
 from src.app.config.config import settings
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -29,6 +30,7 @@ app.include_router(router=auth_router, prefix=settings.API_V1_STR)
 app.include_router(router=webrtc_router, prefix=settings.API_V1_STR)
 app.include_router(router=match_router, prefix=settings.API_V1_STR)
 app.include_router(router=user_router, prefix=settings.API_V1_STR)
+app.include_router(router=game_router, prefix=settings.API_V1_STR)
 
 
 @app.get("/")

--- a/test/app/domain/game/router/test_submit_controller.py
+++ b/test/app/domain/game/router/test_submit_controller.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from src.app.main import app
+
+client = TestClient(app)
+
+@patch("src.app.domain.game.service.game_service.evaluate_code", return_value={"result": "correct", "detail": []})
+def test_submit_correct(mock_eval):
+    data = {"language": "python", "code": "print('hi')"}
+    response = client.post("/api/v1/game/submit", json=data)
+    assert response.status_code == 200
+    assert response.json() == {"result": "correct", "detail": []}
+    mock_eval.assert_called_once_with("python", "print('hi')")
+
+@patch("src.app.domain.game.service.game_service.evaluate_code", return_value={"result": "wrong", "detail": []})
+def test_submit_wrong(mock_eval):
+    data = {"language": "python", "code": "print(\"error\")"}
+    response = client.post("/api/v1/game/submit", json=data)
+    assert response.status_code == 200
+    assert response.json()["result"] == "wrong"
+    mock_eval.assert_called_once()


### PR DESCRIPTION
- 채점 시스템의 엔드포인트를 담는 새로운 환경 변수를 추가

- 새 game 도메인 아래에 `/submit` 경로를 구현하여 판정 서비스에 코드를 전송하고 정답 여부를 반환 (아직 문제가 규격화되어 있지는 않으므로 컴파일 및 실행만 정상적으로 되면 정답 처리됨)

- 새 엔드포인트를 사용할 수 있도록 `main.py`에 `game` 라우터를 등록

- 새 엔드포인트를 통해 제출 성공/실패를 확인하는 테스트 추가

- `.env.example` 파일 추가