### PR TITLE
:bug: [FIX] 매칭 거절 시 상대방도 취소되는 오류 수정, 매칭 취소 시 즉시 대기열에서 제거되도록 수정

### DIFF
--- a/src/app/domain/match/service/match_service.py
+++ b/src/app/domain/match/service/match_service.py
@@ -1,4 +1,4 @@
-from src.app.domain.match.utils.queues import normal_queue, hard_queue, queue_lock
+from src.app.domain.match.utils.queues import hard_queue, normal_queue, queue_lock
 from src.app.domain.match.utils.matcher import hybrid_match, hard_match, force_match
 from datetime import datetime, timezone
 import asyncio
@@ -105,3 +105,6 @@ async def dispatch_pairs(pairs, algo):
 
         # 20초 타임아웃
         asyncio.create_task(handle_match_timeout(match_id, [u1.id, u2.id], 20))
+
+
+match_service = MatchService()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -5,18 +5,16 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
-from src.app.domain.match.service.match_service import MatchService  # ★ 매칭 루프
 from src.app.domain.auth import router as auth_router
 from src.app.domain.webrtc import router as webrtc_router
 from src.app.domain.match import router as match_router
 from src.app.domain.user import router as user_router
 from src.app.domain.game import router as game_router
 from src.app.config.config import settings
+from src.app.domain.match.service.match_service import match_service
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 STATIC_DIR = BASE_DIR / "resource" / "static"
-
-match_service = MatchService()
 
 
 @asynccontextmanager


### PR DESCRIPTION
queue.py 
 - 취소 시 상대편이 재진입 될 수있도록 재진입 합수 추가
 - 취소 시 joinded_at 등의 변수가 이전 값 그대로 가져갈 수 있도록 전역 딕셔너리(캐시 용도) 추가

match_controller 
 - 매칭 수락, 거절 시 캐시에서 정보 삭제되도록 추가
 - 거절 시, 상대편은 재진입 되도록 추가

match_service, main
 - 순환 참조 발생으로 match_service = MatchService()를 메인에서 매치 서비스 파일로 옮김