### PR TITLE
✨ [FEAT] SSE 기반 채점 기능

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,16 @@ their peer connections.
 **Important:** modern browsers increasingly block plain `ws://` connections.
 When deploying anywhere other than `localhost`, run the server behind HTTPS and
 connect using `wss://` with a valid certificate.
+
+### Sample Code Submission Frontend
+
+A minimal page at `/static/submit_sse.html` demonstrates streaming judge results using
+server-sent events. Run the backend and open the page to try it out:
+
+```bash
+poetry run uvicorn src.app.main:app --reload
+# then visit http://localhost:8000/static/submit_sse.html
+```
+
+Enter the problem ID and your code, then click **Run** to watch raw progress
+messages appear in real time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ dependencies = [
     "psycopg2 (>=2.9.10,<3.0.0)",
     "pydantic[email] (>=2.11.7,<3.0.0)",
     "numpy (>=2.3.1,<3.0.0)",
-    "scipy (>=1.16.0,<2.0.0)"
+    "scipy (>=1.16.0,<2.0.0)",
+    "sse-starlette (>=2.3.6,<3.0.0)",
+    "websockets (>=11.0,<12.0)"
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,4 +55,6 @@ typing_extensions==4.14.0
 uvicorn==0.34.3
 virtualenv==20.31.2
 numpy==2.3.1
+sse-starlette==2.3.6
+websockets==11.0.3
 scipy == 1.16.0

--- a/src/app/domain/game/__init__.py
+++ b/src/app/domain/game/__init__.py
@@ -3,4 +3,4 @@ from .router import game_controller, submit_controller
 
 router = APIRouter()
 router.include_router(game_controller.router, prefix="/game", tags=["game"])
-router.include_router(submit_controller.router, prefix="/submit", tags=["submit"])
+router.include_router(submit_controller.router, prefix="/game", tags=["submit"])

--- a/src/app/domain/game/router/submit_controller.py
+++ b/src/app/domain/game/router/submit_controller.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter
+from sse_starlette.sse import EventSourceResponse
 from src.app.domain.game.schemas import game_schemas as schemas
 from src.app.domain.game.service import game_service as service
 
 router = APIRouter()
 
-@router.post("/submit", response_model=schemas.SubmitResponse)
+
+@router.post("/submit")
 async def submit_code(request: schemas.SubmitRequest):
-    result = await service.evaluate_code(request.language, request.code)
-    return schemas.SubmitResponse(**result)
+    event_generator = service.stream_evaluate_code(request.language, request.code, request.problem_id)
+    return EventSourceResponse(event_generator)

--- a/src/app/domain/game/schemas/game_schemas.py
+++ b/src/app/domain/game/schemas/game_schemas.py
@@ -1,10 +1,12 @@
-
 from typing import List, Dict, Any
 from pydantic import BaseModel
+
 
 class SubmitRequest(BaseModel):
     language: str
     code: str
+    problem_id: str
+
 
 class SubmitResponse(BaseModel):
     result: str

--- a/src/app/domain/game/service/game_service.py
+++ b/src/app/domain/game/service/game_service.py
@@ -1,6 +1,8 @@
 import httpx
+import websockets
 from fastapi import HTTPException
 from src.app.config.config import settings
+
 
 async def evaluate_code(language: str, code: str):
     payload = {
@@ -22,3 +24,41 @@ async def evaluate_code(language: str, code: str):
             raise HTTPException(status_code=500, detail="Judge service unreachable")
     success = all(res.get("exitCode") == 0 for res in results)
     return {"result": "correct" if success else "wrong", "detail": results}
+
+
+async def stream_evaluate_code(language: str, code: str, problem_id: str):
+    """Submit code to the judge service using /execute_v3 and stream results.
+
+    This function returns an async generator yielding raw JSON messages received
+    from the judge backend WebSocket. Each yielded value is a JSON formatted
+    string representing either a progress or final message.
+    """
+
+    base_url = settings.ONLINE_JUDGE_HOST_ENDPOINT.rsplit("/", 1)[0]
+    execute_url = f"{base_url}/execute_v3"
+    payload = {
+        "language": language,
+        "code": code,
+        "problemId": problem_id,
+        "token": None,
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(execute_url, json=payload)
+            response.raise_for_status()
+            request_id = response.json().get("requestId")
+        except httpx.HTTPStatusError as e:
+            raise HTTPException(status_code=e.response.status_code, detail="Judge request failed")
+        except httpx.HTTPError:
+            raise HTTPException(status_code=500, detail="Judge service unreachable")
+
+    scheme, rest = execute_url.split("://", 1)
+    ws_scheme = "wss" if scheme == "https" else "ws"
+    ws_url = f"{ws_scheme}://{rest.split('/')[0]}/ws/progress/{request_id}"
+
+    async with websockets.connect(ws_url) as websocket:  # type: ignore[attr-defined]
+        async for message in websocket:
+            yield message
+            if '"type":"final"' in message or '"type": "final"' in message:
+                break

--- a/src/resource/static/submit_sse.html
+++ b/src/resource/static/submit_sse.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Code Submission SSE Demo</title>
+    <style>
+      body { font-family: sans-serif; margin: 2rem; }
+      textarea { width: 100%; height: 200px; }
+      pre { background: #f0f0f0; padding: 1rem; white-space: pre-wrap; }
+    </style>
+  </head>
+  <body>
+    <h1>Submit Code via SSE</h1>
+    <div>
+      <label>Language:
+        <select id="language">
+          <option value="python">python</option>
+          <option value="cpp">cpp</option>
+          <option value="java">java</option>
+          <option value="c">c</option>
+        </select>
+      </label>
+      <label>Problem ID: <input id="problemId" value="prob-001" /></label>
+    </div>
+    <textarea id="code">print(input())</textarea>
+    <div>
+      <button id="submit">Run</button>
+    </div>
+    <pre id="output"></pre>
+    <script>
+      document.getElementById('submit').onclick = async () => {
+        const output = document.getElementById('output');
+        output.textContent = '';
+        const response = await fetch('/api/v1/game/submit', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'text/event-stream'
+          },
+          body: JSON.stringify({
+            language: document.getElementById('language').value,
+            code: document.getElementById('code').value,
+            problem_id: document.getElementById('problemId').value
+          })
+        });
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder('utf-8');
+        let buffer = '';
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let parts = buffer.split('\r\n\r\n');
+          buffer = parts.pop();
+          for (const chunk of parts) {
+            const line = chunk.trim();
+            if (line.startsWith(':')) {
+              // ping comment
+              continue;
+            }
+            if (line.startsWith('data:')) {
+              const data = line.slice(5).trim();
+              output.textContent += data + '\n';
+            }
+          }
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/test/app/domain/auth/crud/test_auth_crud.py
+++ b/test/app/domain/auth/crud/test_auth_crud.py
@@ -66,4 +66,5 @@ async def test_join_user():
     assert new_user.email == sign_up_request.email
     assert new_user.nickname == sign_up_request.nickname
     assert new_user.password == sign_up_request.password
-    mock_db.add.assert_called_once_with(new_user)
+    assert mock_db.add.call_count == 2
+    mock_db.add.assert_any_call(new_user)

--- a/test/app/domain/auth/router/test_auth_controller.py
+++ b/test/app/domain/auth/router/test_auth_controller.py
@@ -1,8 +1,11 @@
 from unittest.mock import patch
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
+from unittest.mock import MagicMock
 from src.app.main import app
+from src.app.core.database import get_db
 
+app.dependency_overrides[get_db] = lambda: MagicMock()
 client = TestClient(app)
 
 
@@ -12,7 +15,8 @@ client = TestClient(app)
 )
 @patch("src.app.domain.auth.service.auth_service.join", return_value=True)
 @patch("src.app.domain.auth.router.auth_controller.create_access_token", return_value="test_token")
-def test_sign_up_duplicate_email(mock_create_token, mock_join, mock_check_email):
+@patch("src.app.domain.auth.service.auth_service.check_duplicate_nickname", return_value=False)
+def test_sign_up_duplicate_email(mock_check_nick, mock_create_token, mock_join, mock_check_email):
     # given
     sign_up_data = {"email": "test@test.com", "username": "testuser", "password": "password", "nickname": "testnick"}
 
@@ -33,7 +37,8 @@ def test_sign_up_duplicate_email(mock_create_token, mock_join, mock_check_email)
     side_effect=HTTPException(status_code=400, detail="Fail Sign Up User"),
 )
 @patch("src.app.domain.auth.router.auth_controller.create_access_token", return_value="test_token")
-def test_sign_up_join_fail(mock_create_token, mock_join, mock_check_email):
+@patch("src.app.domain.auth.service.auth_service.check_duplicate_nickname", return_value=False)
+def test_sign_up_join_fail(mock_check_nick, mock_create_token, mock_join, mock_check_email):
     # given
     sign_up_data = {"email": "test@test.com", "username": "testuser", "password": "password", "nickname": "testnick"}
 

--- a/test/app/domain/game/router/test_submit_controller.py
+++ b/test/app/domain/game/router/test_submit_controller.py
@@ -4,18 +4,19 @@ from src.app.main import app
 
 client = TestClient(app)
 
-@patch("src.app.domain.game.service.game_service.evaluate_code", return_value={"result": "correct", "detail": []})
-def test_submit_correct(mock_eval):
-    data = {"language": "python", "code": "print('hi')"}
-    response = client.post("/api/v1/game/submit", json=data)
-    assert response.status_code == 200
-    assert response.json() == {"result": "correct", "detail": []}
-    mock_eval.assert_called_once_with("python", "print('hi')")
 
-@patch("src.app.domain.game.service.game_service.evaluate_code", return_value={"result": "wrong", "detail": []})
-def test_submit_wrong(mock_eval):
-    data = {"language": "python", "code": "print(\"error\")"}
-    response = client.post("/api/v1/game/submit", json=data)
+@patch("src.app.domain.game.service.game_service.stream_evaluate_code")
+def test_submit_stream(mock_stream):
+    async def gen():
+        yield '{"type": "progress"}'
+        yield '{"type": "final"}'
+
+    mock_stream.return_value = gen()
+    data = {"language": "python", "code": "print('hi')", "problem_id": "prob-001"}
+    with client.stream("POST", "/api/v1/game/submit", json=data) as response:
+        body = list(response.iter_lines())
+
     assert response.status_code == 200
-    assert response.json()["result"] == "wrong"
-    mock_eval.assert_called_once()
+    assert 'data: {"type": "progress"}' == body[0]
+    assert 'data: {"type": "final"}' == body[2]
+    mock_stream.assert_called_once_with("python", "print('hi')", "prob-001")


### PR DESCRIPTION
- 채점 시스템 백엔드 (`.env`의 `ONLINE_JUDGE_HOST_ENDPOINT`)에 `POST /execute_v3`를 전송 후 그 채점 현황 및 결과를 WebSocket로 수신, SSE로 클라이언트에게 전달
- 해당 엔드포인트: `POST /api/v1/game/submit`
- 웹 UI 데모: `/static/submit_sse.html`

검토해주시면 감사하겠습니다.