### PR TITLE
:bug: [FIX] 사용자 정보 수정 및 중복 확인 기능 전체 리팩토링 및 버그 수정

### DIFF
--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -17,10 +17,10 @@ ALGORITHM = "HS256"
 from src.app.core.token import decode_token
 
 
-async def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
     try:
         email = decode_token(token)
-        user = await crud.get_user_by_email(db, email=email)
+        user = crud.get_user_by_email(db, email=email)
         if user is None:
             raise HTTPException(status_code=401, detail="User is None")
         return user

--- a/src/app/domain/auth/crud/auth_crud.py
+++ b/src/app/domain/auth/crud/auth_crud.py
@@ -1,36 +1,36 @@
 from sqlalchemy.orm import Session
 from src.app.models.models import User, UserMmr, UserRole
 from src.app.domain.auth.schemas import auth_schemas as schemas
-from typing import Optional  # 추가 코드
+from typing import Optional
 
 
-async def get_user_by_email(db: Session, email: str) -> Optional[User]:  # User -> Optional[User]로 수정
+def get_user_by_email(db: Session, email: str) -> Optional[User]:
     return db.query(User).filter(User.email == email).first()
 
 
-async def get_by_email(db: Session, email: str) -> bool:
+def get_by_email(db: Session, email: str) -> bool:
     search_email = db.query(User).filter(User.email == email).first()
     return True if search_email else False
 
 
-async def get_by_nickname(db: Session, nickname: str) -> bool:
+def get_by_nickname(db: Session, nickname: str) -> bool:
     return db.query(User).filter(User.nickname == nickname).first() is not None
 
 
-async def join_user(db: Session, sign_up_request: schemas.UserSignupRequest) -> User:
+def join_user(db: Session, sign_up_request: schemas.SignupRequest, mmr: int, use_lang: str) -> User:
     new_user = User(
-        username=sign_up_request.username,
         email=str(sign_up_request.email),
+        username=sign_up_request.username,
         nickname=sign_up_request.nickname,
         role=UserRole.USER,
-        password=sign_up_request.password,  # 해시된 값
-        use_lang=sign_up_request.use_lang,  # 사용언어 선택
+        password=sign_up_request.password,
+        use_lang=sign_up_request.use_lang,
     )
     db.add(new_user)
-    # mmr db 반영 추가
     db.flush()
     db.refresh(new_user)
-    mmr_row = UserMmr(user_id=new_user.user_id)
+
+    mmr_row = UserMmr(user_id=new_user.user_id, rating=mmr)
     db.add(mmr_row)
 
     return new_user

--- a/src/app/domain/auth/router/auth_controller.py
+++ b/src/app/domain/auth/router/auth_controller.py
@@ -1,14 +1,14 @@
 from typing import Annotated
-
+import traceback
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
+from fastapi import APIRouter, Depends, HTTPException, Response
 
 from src.app.core.database import get_db
 from src.app.domain.auth.schemas import auth_schemas as schemas
 from src.app.domain.auth.service import auth_service as service
 from src.app.core.token import create_access_token
 from src.app.domain.auth.crud import auth_crud as crud
-from fastapi import APIRouter, Depends, HTTPException, status, Response
 
 router = APIRouter()
 
@@ -16,70 +16,51 @@ DB = Annotated[Session, Depends(get_db)]
 
 
 @router.post("/sign-up")
-async def sign_up(response: Response, sign_up_request: schemas.UserSignupRequest, db: DB):
+async def sign_up(sign_up_request: schemas.SignupRequest, db: DB):
     try:
-        # 1. 이메일이 있는지(중복 가입) 확인한다.
         await service.check_duplicate_email(db, str(sign_up_request.email))
-        # 2. 닉네임이 있는지(중복 여부) 확인한다.
-        await service.check_duplicate_nickname(db, sign_up_request.nickname)  # ← 추가
-        # 3. 회원가입 진행
+        await service.check_duplicate_nickname(db, sign_up_request.nickname)
         await service.join(db, sign_up_request)
         db.commit()
-        # 3. 회원가입 성공 시 새로운 acces_token 생성
-        access_token = create_access_token(subject=sign_up_request.email)
-        # 4. 반환
+
+        access_token = create_access_token(subject=str(sign_up_request.email))
         return schemas.TokenResponse(access_token=access_token)
+
     except HTTPException:
         db.rollback()
         raise
     except Exception as e:
-        print("회원가입 에러:", repr(e))  # 에러 내용 자세히 출력
-        raise HTTPException(status_code=500, detail="서버 오류로 회원가입에 실패했습니다.")
+        print("회원가입 중 에러 발생:", e)
+        traceback.print_exc()
+        raise
 
 
 @router.post("/login")
 async def login(
     db: DB,
-    from_data: OAuth2PasswordRequestForm = Depends(),
+    response: Response,
+    form_data: OAuth2PasswordRequestForm = Depends(),
 ):
     try:
-        user = await service.authenticate_user(db, from_data.username, from_data.password)
-
+        user = await service.authenticate_user(db, form_data.username, form_data.password)
         access_token = create_access_token(subject=user.email)
-        return schemas.TokenResponse(access_token=access_token)
+
+        response.set_cookie(
+            key="access_token",
+            value=access_token,
+            httponly=True,
+            max_age=60 * 60 * 24,
+            secure=False,
+            samesite="lax",
+        )
+
+        return {"access_token": access_token, "token_type": "bearer"}
+
     except HTTPException as e:
         raise e
     except Exception as e:
-        print(e)
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal Server Error")
-
-
-@router.post("/logout")
-async def logout(response: Response):
-    response.delete_cookie("access_token")  # 쿠키 사용 시
-    return {"message": "로그아웃 되었습니다."}
-
-
-@router.get("/find-id")
-async def find_id(email: str, db: DB):
-    user = await crud.get_user_by_email(db, email)
-    if not user:
-        raise HTTPException(status_code=404, detail="등록되지 않은 이메일입니다.")
-    return {"username": user.username, "nickname": user.nickname}
-
-
-@router.get("/check-email")
-async def check_email(email: str, db: DB):
-    if await service.check_email_exists(db, email):
-        raise HTTPException(status_code=400, detail="이미 사용 중인 이메일입니다.")
-    return {"available": True}
-
-
-@router.get("/check-nickname")
-async def check_nickname(nickname: str, db: DB):
-    if await service.check_nickname_exists(db, nickname):
-        raise HTTPException(status_code=400, detail="이미 사용 중인 닉네임입니다.")
-    return {"available": True}
+        print("로그인 에러:", repr(e))
+        raise HTTPException(status_code=500, detail="서버 오류로 로그인에 실패했습니다.")
 
 
 @router.post("/reset-password/request")
@@ -98,3 +79,23 @@ async def verify_reset_code(email: str, code: str, db: DB):
 async def complete_password_reset(email: str, code: str, new_password: str, db: DB):
     await service.reset_password(db, email, code, new_password)
     return {"message": "비밀번호가 성공적으로 변경되었습니다."}
+
+
+@router.get("/find-id")
+async def find_id(email: str, db: DB):
+    user = crud.get_user_by_email(db, email)
+    if not user:
+        raise HTTPException(status_code=404, detail="등록되지 않은 이메일입니다.")
+    return {"username": user.username, "nickname": user.nickname}
+
+
+@router.get("/check-email")
+async def check_email(email: str, db: DB):
+    await service.check_duplicate_email(db, email)
+    return {"available": True}
+
+
+@router.get("/check-nickname")
+async def check_nickname(nickname: str, db: DB):
+    await service.check_duplicate_nickname(db, nickname)
+    return {"available": True}

--- a/src/app/domain/auth/schemas/auth_schemas.py
+++ b/src/app/domain/auth/schemas/auth_schemas.py
@@ -3,22 +3,16 @@ from pydantic import BaseModel, constr, EmailStr
 from src.app.config.config import settings
 
 
-class TokenResponse(BaseModel):
-    access_token: str
-    refresh_token: Optional[str] = None
-    token_type: str = "bearer"
-    expires_in: int = settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
-
-
-class UserSignupRequest(BaseModel):
+class SignupRequest(BaseModel):
     email: EmailStr
     username: str
     password: constr(min_length=8, max_length=20)
     nickname: str
-    use_lang: Optional[str] = "python3"  # 기본값 주자
+    use_lang: str  # 예: Python, Java, C, C++
+    tier_choice: str  # 예: 브론즈, 실버, 골드, 플래티넘 이상, 티어 없음
 
 
-class UserSignupResponse(BaseModel):
+class SignupResponse(BaseModel):
     email: str
     username: str
     nickname: str
@@ -26,7 +20,14 @@ class UserSignupResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class UserDto(BaseModel):
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: Optional[str] = None
+    token_type: str = "bearer"
+    expires_in: int = settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+
+
+class LoginUserDto(BaseModel):
     email: str
     username: str
     nickname: str

--- a/src/app/domain/auth/service/auth_service.py
+++ b/src/app/domain/auth/service/auth_service.py
@@ -1,89 +1,86 @@
 import secrets
-import datetime
-
+from datetime import datetime, timedelta, timezone
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
+
 from src.app.domain.auth.crud import auth_crud as crud
 from src.app.domain.auth.schemas import auth_schemas as schemas
 from src.app.core.password import get_password_hash, verify_password
-from src.app.models.models import User
-from src.app.utils.email import send_email  # 너희 메일 전송 유틸
+from src.app.utils.email import send_email
+from src.app.domain.user.schemas.user_schemas import convert_choice_to_mmr
 
 reset_code_store = {}
 
 
-async def check_duplicate_email(db: Session, email: str) -> bool:
-    query_email_result = await crud.get_by_email(db=db, email=email)
-    if query_email_result:
-        raise HTTPException(detail="이미 사용 중인 이메일 입니다.", status_code=status.HTTP_400_BAD_REQUEST)
-    return False
+async def check_duplicate_email(db: Session, email: str) -> None:
+    if crud.get_by_email(db=db, email=email):
+        raise HTTPException(detail="이미 사용 중인 이메일입니다.", status_code=status.HTTP_400_BAD_REQUEST)
 
 
-async def check_duplicate_nickname(db: Session, nickname: str) -> bool:
-    user = db.query(User).filter(User.nickname == nickname).first()
-    if user:
-        raise HTTPException(detail="이미 사용 중인 닉네임 입니다.", status_code=status.HTTP_400_BAD_REQUEST)
-    return False
+async def check_duplicate_nickname(db: Session, nickname: str) -> None:
+    if crud.get_by_nickname(db, nickname):
+        raise HTTPException(detail="이미 사용 중인 닉네임입니다.", status_code=status.HTTP_400_BAD_REQUEST)
 
 
-async def join(db: Session, sign_up_request: schemas.UserSignupRequest) -> schemas.UserSignupResponse:
-    # 1. 비밀 번호 해시
-    hashed_password = get_password_hash(sign_up_request.password)
-    sign_up_request.password = hashed_password
-    # 2. crud 로직에 회원 저장 로직을 호출한다.
-    join_user = await crud.join_user(db=db, sign_up_request=sign_up_request)
-    if not join_user:
-        raise HTTPException(detail="Fail Sign Up User", status_code=status.HTTP_400_BAD_REQUEST)
-        # 3. 저장에 성공하면 True 실패하면 False를 반환받는다.
-    return schemas.UserSignupResponse.model_validate(join_user)
+async def join(db: Session, sign_up_request: schemas.SignupRequest) -> schemas.SignupResponse:
+    sign_up_request.password = get_password_hash(sign_up_request.password)
+    mmr = convert_choice_to_mmr(sign_up_request.tier_choice)
+
+    new_user = crud.join_user(db=db, sign_up_request=sign_up_request, use_lang=sign_up_request.use_lang, mmr=mmr)
+
+    if not new_user:
+        raise HTTPException(detail="Fail Sign Up User", status_code=400)
+
+    return schemas.SignupResponse.model_validate(new_user)
 
 
-async def authenticate_user(db: Session, email: str, password: str) -> schemas.UserDto:
-    # 1. 유저 정보 조회
-    user = await crud.get_user_by_email(db=db, email=email)
-    if not user:
-        raise HTTPException(detail="Invalid User Data", status_code=status.HTTP_401_UNAUTHORIZED)
-    if not await verify_password(password, user.password):
-        raise HTTPException(detail="Invalid Password", status_code=status.HTTP_401_UNAUTHORIZED)
-    return schemas.UserDto.model_validate(user)
+async def authenticate_user(db: Session, email: str, password: str) -> schemas.LoginUserDto:
+    user = crud.get_user_by_email(db, email)  # ✅ await 제거
+    if not user or not verify_password(password, user.password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="이메일 또는 비밀번호가 올바르지 않습니다."
+        )
+    return schemas.LoginUserDto.model_validate(user)
 
 
-# 이메일 존재 여부 확인
-async def check_email_exists(db: Session, email: str) -> bool:
-    return await crud.get_by_email(db, email)
+def check_email_exists(db: Session, email: str) -> bool:
+    return crud.get_by_email(db, email) is not None
 
 
-# 닉네임 존재 여부 확인
-async def check_nickname_exists(db: Session, nickname: str) -> bool:
-    return await crud.get_by_nickname(db, nickname)
+def check_nickname_exists(db: Session, nickname: str) -> bool:
+    return crud.get_by_nickname(db, nickname) is not None
 
 
 async def send_reset_password_email(db: Session, email: str):
-    user = await crud.get_user_by_email(db, email)
+    user = crud.get_user_by_email(db, email)
     if not user:
         raise HTTPException(status_code=404, detail="등록되지 않은 이메일입니다.")
-    code = secrets.token_hex(3)  # 예: "a1b2c3"
-    expires = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
+
+    code = secrets.token_hex(3)
+    expires = datetime.now(timezone.utc) + timedelta(minutes=10)
     reset_code_store[email] = (code, expires)
+
     await send_email(to=email, subject="비밀번호 초기화", body=f"인증코드: {code}")
 
 
-async def verify_reset_code(db: Session, email: str, code: str):
+async def verify_reset_code(email: str, code: str):
     stored = reset_code_store.get(email)
     if not stored:
         raise HTTPException(status_code=400, detail="인증 요청이 없습니다.")
     if stored[0] != code:
         raise HTTPException(status_code=400, detail="잘못된 인증 코드입니다.")
-    if stored[1] < datetime.datetime.utcnow():
+    if stored[1] < datetime.now(timezone.utc):
         raise HTTPException(status_code=400, detail="인증 코드가 만료되었습니다.")
 
 
 async def reset_password(db: Session, email: str, code: str, new_password: str):
-    await verify_reset_code(db, email, code)
-    user = await crud.get_user_by_email(db, email)
+    await verify_reset_code(email, code)
+
+    user = crud.get_user_by_email(db, email)
     if not user:
         raise HTTPException(status_code=404, detail="유저 없음")
+
     user.password = get_password_hash(new_password)
     db.add(user)
     db.commit()
-    reset_code_store.pop(email, None)  # 인증 코드 제거
+    reset_code_store.pop(email, None)

--- a/src/app/domain/user/crud/user_crud.py
+++ b/src/app/domain/user/crud/user_crud.py
@@ -1,9 +1,18 @@
 from sqlalchemy.orm import Session
 from src.app.models.models import User, UserMmr
-from typing import  Optional
+from typing import Optional
 
-async def get_user_by_id(db: Session, input_id: int) -> Optional[User]:
+
+def get_user_by_id(db: Session, input_id: int) -> Optional[User]:
     return db.query(User).filter(User.user_id == input_id).first()
+
+
+def update_user(db: Session, user: User):
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
 
 def get_user_mmr(db: Session, user_id: int) -> int:
     mmr_obj = db.query(UserMmr).filter(UserMmr.user_id == user_id).first()

--- a/src/app/domain/user/schemas/user_schemas.py
+++ b/src/app/domain/user/schemas/user_schemas.py
@@ -1,15 +1,41 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, EmailStr, HttpUrl, ConfigDict, model_validator
+from typing import Optional
+from datetime import datetime
+from fastapi import HTTPException
 
 
+# ✅ MMR 상세 표현용
+class MyMmr(BaseModel):
+    name: Optional[str] = None  # 티어 이름 (예: 브론즈, 실버)
+    level: Optional[int] = None  # 단계 (로마자: I, II, III, IV, V)
+    lp: Optional[int] = None  # LP 점수
+
+
+# ✅ 사용자 정보 수정 요청
+class UserUpdateRequest(BaseModel):
+    current_password: Optional[str] = None  # 변경 전 비밀번호 확인용
+    new_password: Optional[str] = None
+    nickname: Optional[str] = None
+    profile_img_url: Optional[HttpUrl] = None
+
+
+# ✅ 최소 정보 반환용
+class UserResponse(BaseModel):
+    email: EmailStr
+
+
+# ✅ 단순 사용자 정보 반환용
 class UserResponseDto(BaseModel):
     user_id: int
     email: str
     username: str
     nickname: str
+    use_lang: str
 
     model_config = {"from_attributes": True}
 
 
+# ✅ 사용자 요청 DTO
 class UserRequestDto(BaseModel):
     user_id: int
     email: str
@@ -19,10 +45,100 @@ class UserRequestDto(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+# ✅ MMR → 티어명 + 숫자레벨 + LP 변환
+def parse_tier_from_mmr(mmr: int) -> tuple[str, int, int]:
+    tiers = ["bronze", "silver", "gold", "platinum", "diamond", "challenger"]
+    base_mmr = 1000
+    lp = mmr % 100
+    mmr_without_lp = mmr - lp
+    gap = (mmr_without_lp - base_mmr) // 100  # 단계 수
+    tier_index = gap // 5
+    level_num = 5 - (gap % 5)  # 5~1
+
+    if 0 <= tier_index < len(tiers) and 1 <= level_num <= 5:
+        name = tiers[tier_index]
+        level = level_num  # 숫자 그대로 반환
+        return name, level, lp
+
+    return "Unknown", 0, lp
+
+
+# ✅ tier_choice 문자열("bronze 3", "silver 1", 등) → 시작 MMR로 변환
+def convert_choice_to_mmr(tier_choice: str) -> int:
+    tier_base = {
+        "bronze": 1000,
+        "silver": 1500,
+        "gold": 2000,
+    }
+
+    # 예외 처리: 고정 티어
+    if tier_choice == "platinum+":
+        return 2500
+    if tier_choice == "unranked":
+        return 1000
+
+    try:
+        tier, level_str = tier_choice.lower().split()
+        level = int(level_str)
+
+        if tier not in tier_base:
+            raise ValueError(f"Unknown tier: {tier}")
+        if not 1 <= level <= 5:
+            raise ValueError("Level must be between 1 and 5")
+
+        base = tier_base[tier]
+        mmr = base + (5 - level) * 100  # 역순
+        return mmr
+
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid tier_choice: {e}")
+
+
+# ✅ 전체 사용자 정보 반환용 (MMR 자동 가공 포함)
 class UserDto(BaseModel):
     user_id: int
     email: str
     username: str
     nickname: str
+    use_lang: str
+    profile_img_url: Optional[HttpUrl] = None
+    my_mmr: Optional[MyMmr] = None  # 변환된 형태로 제공
 
     model_config = ConfigDict(from_attributes=True)
+
+    @classmethod
+    @model_validator(mode="before")
+    def parse_mmr(cls, values: dict):
+        raw_mmr = values.get("my_mmr")
+        if isinstance(raw_mmr, int):
+            name, level, lp = parse_tier_from_mmr(raw_mmr)
+            values["my_mmr"] = MyMmr(name=name, level=level, lp=lp)
+        return values
+
+
+# ✅ 최근 경기 기록용
+class MatchRecord(BaseModel):
+    match_id: int
+    result: str
+    played_at: datetime
+
+
+# ✅ 마이페이지에서 최근 경기 포함 응답
+class UserResponseWithMatches(UserResponse):
+    recent_matches: list[MatchRecord] = []
+
+
+class UserUpdateResponse(BaseModel):
+    message: str
+    user: UserResponseDto
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserSignupRequest(BaseModel):
+    email: EmailStr
+    username: str
+    password: str
+    nickname: str
+    use_lang: str  # Python, Java, C, C++
+    tier_choice: str  # 브론즈, 실버, 골드, 플래티넘 이상, 티어 없음

--- a/src/app/domain/user/service/user_service.py
+++ b/src/app/domain/user/service/user_service.py
@@ -2,13 +2,47 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 from src.app.domain.user.crud import user_crud as crud
 from src.app.domain.user.schemas import user_schemas as schemas
+from src.app.core.password import get_password_hash, verify_password as verify_pw
 
 
 async def get_user_data(db: Session, input_id: int) -> schemas.UserDto:
-    user = await crud.get_user_by_id(db, input_id=input_id)
+    user = crud.get_user_by_id(db, input_id=input_id)
     if not user:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
-        )
+        raise HTTPException(status_code=404, detail="User not found")
+    return schemas.UserDto.model_validate(user)
+
+
+async def update_my_profile(
+    db: Session,
+    user_id: int,
+    nickname: str | None,
+    current_password: str | None,
+    new_password: str | None,
+    profile_img_url: str | None = None,
+):
+    user = crud.get_user_by_id(db, user_id)
+
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if new_password:
+        if not current_password:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="현재 비밀번호를 입력해야 합니다.",
+            )
+        if not verify_pw(current_password, user.password):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="현재 비밀번호가 일치하지 않습니다.",
+            )
+        user.password = get_password_hash(new_password)
+
+    if nickname:
+        user.nickname = nickname
+
+    if profile_img_url:
+        user.profile_img_url = profile_img_url
+
+    crud.update_user(db, user)
     return user


### PR DESCRIPTION
- 마이페이지 사용자 정보 조회(/me), 수정(/me) API에서 profile_img_url 업데이트 기능 추가
- schemas.UserUpdateRequest 스키마에서 profile_img_url 필드 추가 및 검증
- HttpUrl 필드의 SQLAlchemy 저장 오류 수정 (Text로 처리)
- user_service.py에서 비밀번호 변경 시 현재 비밀번호 검증 추가
- verify_password 중복 함수 제거 → password.py의 verify_pw 함수만 사용하도록 통일
- check-email, check-nickname API의 await 처리 문제 해결 및 동기 방식으로 리팩토링
- check_email_exists, check_nickname_exists 함수 비동기 → 동기 함수로 변경
- find-id API 동작 유지 확인, check-email/nickname API가 작동하지 않던 버그 해결
- 중복 확인 API에서 잘못된 await 사용으로 인해 coroutine warning 발생한 문제 해결
- auth_controller.py의 중복 이메일/닉네임 확인 API 전체 안정화 및 로직 정리