### PR TITLE
:sparkles: [Feat] 유저가 게임을 완료/중단 할 시, 승패 판단하여 Match 및 MatchLog 최신화 하는기능 추가, MatchLog 에 상대 mmr과 rd 값 추가, MatchLog 생성 함수에 반영 하기 위해 수정

### DIFF
--- a/src/app/domain/auth/schemas/auth_schemas.py
+++ b/src/app/domain/auth/schemas/auth_schemas.py
@@ -9,7 +9,7 @@ class SignupRequest(BaseModel):
     password: constr(min_length=8, max_length=20)
     nickname: str
     use_lang: str  # 예: Python, Java, C, C++
-    tier_choice: str  # 예: 브론즈, 실버, 골드, 플래티넘 이상, 티어 없음
+    # tier_choice: str  # 예: 브론즈, 실버, 골드, 플래티넘 이상, 티어 없음
 
 
 class SignupResponse(BaseModel):

--- a/src/app/domain/auth/service/auth_service.py
+++ b/src/app/domain/auth/service/auth_service.py
@@ -7,7 +7,6 @@ from src.app.domain.auth.crud import auth_crud as crud
 from src.app.domain.auth.schemas import auth_schemas as schemas
 from src.app.core.password import get_password_hash, verify_password
 from src.app.utils.email import send_email
-from src.app.domain.user.schemas.user_schemas import convert_choice_to_mmr
 
 reset_code_store = {}
 
@@ -24,8 +23,8 @@ async def check_duplicate_nickname(db: Session, nickname: str) -> None:
 
 async def join(db: Session, sign_up_request: schemas.SignupRequest) -> schemas.SignupResponse:
     sign_up_request.password = get_password_hash(sign_up_request.password)
-    mmr = convert_choice_to_mmr(sign_up_request.tier_choice)
-
+    # mmr = convert_choice_to_mmr(sign_up_request.tier_choice)
+    mmr = 1000
     new_user = crud.join_user(db=db, sign_up_request=sign_up_request, use_lang=sign_up_request.use_lang, mmr=mmr)
 
     if not new_user:

--- a/src/app/domain/game/crud/game_crud.py
+++ b/src/app/domain/game/crud/game_crud.py
@@ -1,0 +1,88 @@
+from src.app.domain.user.crud.user_crud import get_user_by_id
+from src.app.domain.match.utils.mmr_measure import full_update, MatchScore
+from src.app.models.models import MatchResult, MatchFinishStatus, MatchStatus
+from src.app.domain.match.crud.match_crud import get_log_by_id, get_mmr_by_id
+from sqlalchemy.orm import Session
+from src.app.models.models import Match
+from datetime import datetime, timezone
+
+RESULT_TO_SCORE = {
+    MatchResult.WIN: MatchScore.WIN,
+    MatchResult.DRAW: MatchScore.DRAW,
+    MatchResult.LOSS: MatchScore.LOSS,
+}
+
+
+async def update_user_mmr(db: Session, user_id: int) -> None:
+    user_info = await get_user_by_id(db, user_id)
+    user_mmr_info = await get_mmr_by_id(db, user_id)
+    match_log = await get_log_by_id(db, user_id)
+
+    if None in (user_info, user_mmr_info, match_log):
+        return
+
+    ori_mmr = user_info.my_tier
+
+    enemy_mmr = match_log.opponent_mmr
+    enemy_rd = match_log.opponent_rd
+    score_enum = RESULT_TO_SCORE[match_log.result]  # ← Enum 변환
+    game = [(enemy_mmr, enemy_rd, score_enum)]
+
+    new_rate, new_rd, new_sigma = full_update(
+        user_info.my_tier, user_mmr_info.rating_devi, user_mmr_info.volatility, game
+    )
+
+    user_info.my_tier = new_rate
+    user_mmr_info.rating_devi = int(new_rd)
+    user_mmr_info.volatility = new_sigma
+
+    match_log.mmr_earned = new_rate - ori_mmr
+    match_log.is_consumed = True
+
+    db.commit()
+
+    return
+
+
+async def update_user_log(db: Session, game_id: int, user_id: int, result: str) -> None:
+    # MatchLog 가져오기
+    user_log = await get_log_by_id(db, user_id)
+
+    # 결과 기록
+    if result == "win":
+        user_log.result = MatchResult.WIN
+
+    elif result == "loss":
+        user_log.result = MatchResult.LOSS
+
+    elif result == "draw":
+        user_log.result = MatchResult.DRAW
+
+    else:
+        raise ValueError(f"Invalid result '{result}' passed to update_user_log.")
+
+    db.flush()
+
+    return await update_user_mmr(db, user_id)
+
+
+async def update_match(db: Session, match_id: int, reason: str) -> None:
+    now = datetime.now(timezone.utc)
+    match = db.query(Match).filter(Match.match_id == match_id).first()
+
+    match.status = MatchStatus.FINISH
+    match.ending_status = MatchFinishStatus(reason)
+    match.updated_at = now
+    match.finished_at = now
+
+    db.commit()
+
+
+async def search_result(db: Session, user_id: int) -> str:
+    match_log = await get_log_by_id(db, user_id)
+    if match_log.result == MatchResult.WIN:
+        return "win"
+    elif match_log.result == MatchResult.LOSS:
+        return "loss"
+    else:
+        return "draw"

--- a/src/app/domain/game/router/game_controller.py
+++ b/src/app/domain/game/router/game_controller.py
@@ -1,7 +1,7 @@
 from fastapi import Depends, WebSocket, WebSocketDisconnect, APIRouter, Query
 from src.app.utils.game_session import game_rooms, game_user_map, ready_status
 import json
-from src.app.domain.game.crud.game_crud import update_user_log, update_match, search_result
+from src.app.domain.game.service.game_result_service import update_user_log, update_match, search_result
 from typing import Annotated
 from sqlalchemy.orm import Session
 from src.app.core.database import get_db

--- a/src/app/domain/game/router/game_controller.py
+++ b/src/app/domain/game/router/game_controller.py
@@ -1,12 +1,17 @@
-from fastapi import WebSocket, WebSocketDisconnect, APIRouter, Query
+from fastapi import Depends, WebSocket, WebSocketDisconnect, APIRouter, Query
 from src.app.utils.game_session import game_rooms, game_user_map, ready_status
 import json
+from src.app.domain.game.crud.game_crud import update_user_log, update_match, search_result
+from typing import Annotated
+from sqlalchemy.orm import Session
+from src.app.core.database import get_db
 
 router = APIRouter()
+DB = Annotated[Session, Depends(get_db)]
 
 
 @router.websocket("/ws/game/{game_id}")
-async def game_websocket(websocket: WebSocket, game_id: int, user_id: int = Query(...)):
+async def game_websocket(db: DB, websocket: WebSocket, game_id: int, user_id: int = Query(...)):
     game_id = int(game_id)
     user_id = int(user_id)
 
@@ -24,7 +29,7 @@ async def game_websocket(websocket: WebSocket, game_id: int, user_id: int = Quer
             # 클라이언트에서 받은 메시지를 처리 핸들러로 전달
             message = await websocket.receive_text()
 
-            await handle_game_message(websocket, game_id, user_id, message)
+            await handle_game_message(db, websocket, game_id, user_id, message)
 
     except WebSocketDisconnect:
         # 연결 종료 시 정리
@@ -41,7 +46,8 @@ async def game_websocket(websocket: WebSocket, game_id: int, user_id: int = Quer
             ready_status.pop(game_id, None)
 
 
-async def handle_game_message(websocket: WebSocket, game_id: int, user_id: int, message: str):
+async def handle_game_message(db, websocket: WebSocket, game_id: int, user_id: int, message: str):
+    opponent_id = [uid for uid in game_user_map[game_id] if uid != user_id][0]
     try:
         data = json.loads(message)
         message_type = data.get("type")
@@ -68,11 +74,12 @@ async def handle_game_message(websocket: WebSocket, game_id: int, user_id: int, 
             print(f"채점 요청: 사용자 {user_id}, 코드: {data.get('code')}")
             await websocket.send_json({"type": "submission_received"})
 
+        # 제출 / 시간초과 / 항복 시 여기로
+        # 각 reason 은 "finish" / "timeout" / "surrender"
         elif message_type == "match_result":
-            # 게임 종료: 결과 공유
-            await broadcast_to_room(
-                game_id, {"type": "match_result", "winner": data.get("winner"), "reason": data.get("reason")}
-            )
+            reason = data.get("reason")
+            winner_id, reason = await process_match_result(db, game_id, user_id, opponent_id, reason)
+            await websocket.send_json({"type": "match_result", "winner": winner_id, "reason": reason})
 
         else:
             await websocket.send_json({"type": "error", "message": "Unknown message type"})
@@ -86,3 +93,44 @@ async def broadcast_to_room(game_id: int, message: dict, exclude: WebSocket = No
     for ws in game_rooms[game_id]:
         if ws != exclude:
             await ws.send_json(message)
+
+
+async def process_match_result(
+    db: Session, game_id: int, user_id: int, opponent_id: int, reason: str
+) -> (int | None, str):
+    opponent_result = search_result(db, opponent_id)
+    # 기권 시
+    if reason in ("surrender", "abandon"):
+        await update_user_log(db, game_id, user_id, "loss")
+        if opponent_result == "lose":
+            await update_match(db, game_id, "abnormal")
+        # 패배
+        return opponent_id, "surrender"
+    # 시간 초과 시
+    elif reason == "timeout":
+        # 상대방 상태 판단
+        if opponent_result == "loss":
+            await update_user_log(db, game_id, user_id, "win")
+            await update_match(db, game_id, "abnormal")
+            # 상대 기권 시 부전승
+            return user_id, "walkover"
+
+        elif opponent_result == "win":
+            await update_user_log(db, game_id, user_id, "loss")
+            # 상대가 이미 제출 완료 시 패배
+            return opponent_id, "late"
+
+        else:
+            # 상대 또한 timeout 일 시, 무승부
+            await update_user_log(db, game_id, user_id, "draw")
+            await update_match(db, game_id, "draw")
+            return None, "draw"
+
+    else:
+        if opponent_result == "win":
+            await update_user_log(db, game_id, user_id, "loss")
+            return opponent_id, "late"
+        else:
+            await update_user_log(db, game_id, user_id, "win")
+            await update_match(db, game_id, "normal")
+            return user_id, "finish"

--- a/src/app/domain/game/service/game_result_service.py
+++ b/src/app/domain/game/service/game_result_service.py
@@ -70,11 +70,11 @@ async def update_match(db: Session, match_id: int, reason: str) -> None:
     now = datetime.now(timezone.utc)
     match = db.query(Match).filter(Match.match_id == match_id).first()
 
-    match.status = MatchStatus.FINISH
+    match.matching_status = MatchStatus.FINISH
     match.ending_status = MatchFinishStatus(reason)
     match.updated_at = now
     match.finished_at = now
-
+    db.commit()
 
 async def search_result(db: Session, game_id: int, user_id: int) -> str | None:
     match_log = await get_log_by_game_id(db, game_id, user_id)

--- a/src/app/domain/match/crud/match_crud.py
+++ b/src/app/domain/match/crud/match_crud.py
@@ -1,7 +1,5 @@
-from src.app.models.models import MatchLog, MatchResult
+from src.app.models.models import MatchLog
 from typing import Optional
-from src.app.domain.match.utils.mmr_measure import full_update, MatchScore
-from src.app.domain.user.crud.user_crud import get_user_by_id
 from sqlalchemy.orm import Session
 from src.app.models.models import Match, UserMmr
 
@@ -14,82 +12,6 @@ async def get_log_by_id(db: Session, input_id: int) -> Optional[MatchLog]:
     return db.query(MatchLog).filter(MatchLog.user_id == input_id, MatchLog.is_consumed.is_(False)).first()
 
 
-RESULT_TO_SCORE = {
-    MatchResult.WIN: MatchScore.WIN,
-    MatchResult.DRAW: MatchScore.DRAW,
-    MatchResult.LOSS: MatchScore.LOSS,
-}
-
-
-async def update_users_mmr(db: Session, user_id: int) -> None:
-    user_info = await get_user_by_id(db, user_id)
-    user_mmr_info = await get_mmr_by_id(db, user_id)
-    match_log = await get_log_by_id(db, user_id)
-
-    if None in (user_info, user_mmr_info, match_log):
-        return
-
-    ori_mmr = user_info.my_tier
-
-    enemy_mmr = match_log.opponent_mmr
-    enemy_rd = match_log.opponent_rd
-    score_enum = RESULT_TO_SCORE[match_log.result]  # ← Enum 변환
-    game = [(enemy_mmr, enemy_rd, score_enum)]
-
-    new_rate, new_rd, new_sigma = full_update(
-        user_info.my_tier, user_mmr_info.rating_devi, user_mmr_info.volatility, game
-    )
-
-    user_info.my_tier = new_rate
-    user_mmr_info.rating_devi = int(new_rd)
-    user_mmr_info.volatility = new_sigma
-
-    match_log.mmr_earned = new_rate - ori_mmr
-    match_log.is_consumed = True
-
-    db.commit()
-
-    return
-
-
-async def create_log(db: Session, match_id: int, user_a_id: int, user_b_id: int, winner: int | None) -> None:
-    user_a = await get_user_by_id(db, user_a_id)
-    user_b = await get_user_by_id(db, user_b_id)
-    user_a_mmr = await get_mmr_by_id(db, user_a_id)
-    user_b_mmr = await get_mmr_by_id(db, user_b_id)
-
-    user_a_log = MatchLog(
-        user_id=user_a_id,
-        match_id=match_id,
-        mmr_earned=0,
-        opponent_mmr=user_b.my_tier,
-        opponent_rd=user_b_mmr.rating_devi,
-    )
-
-    user_b_log = MatchLog(
-        user_id=user_b_id,
-        match_id=match_id,
-        mmr_earned=0,
-        opponent_mmr=user_a.my_tier,
-        opponent_rd=user_a_mmr.rating_devi,
-    )
-
-    if not winner:
-        user_a_log.result = MatchResult.DRAW
-        user_b_log.result = MatchResult.DRAW
-    else:
-        if winner == user_a.user_id:
-            user_a_log.result = MatchResult.WIN
-            user_b_log.result = MatchResult.LOSS
-        else:
-            user_a_log.result = MatchResult.LOSS
-            user_b_log.result = MatchResult.WIN
-
-    db.add_all([user_a_log, user_b_log])
-    db.commit()
-    return
-
-
 async def create_match(db: Session, problem_id: int):
     match = Match(problem_id=problem_id, matching_status="created")
     db.add(match)
@@ -99,11 +21,27 @@ async def create_match(db: Session, problem_id: int):
 
 
 async def create_match_logs(db: Session, match_id: int, user_ids: list[int], problem_id: int):
-    for uid in user_ids:
-        db.add(
-            MatchLog(
-                match_id=match_id,
-                user_id=uid,
-                problem_id=problem_id,
-            )
-        )
+    user_a_mmr = await get_mmr_by_id(db, user_ids[0])
+    user_b_mmr = await get_mmr_by_id(db, user_ids[1])
+
+    user_a_log = MatchLog(
+        match_id=match_id,
+        problem_id=problem_id,
+        user_id=user_ids[0],
+        is_consumed=False,
+        opponent_mmr=user_b_mmr.rating,
+        opponent_rd=user_b_mmr.rating_devi,
+    )
+
+    user_b_log = MatchLog(
+        match_id=match_id,
+        problem_id=problem_id,
+        user_id=user_ids[1],
+        is_consumed=False,
+        opponent_mmr=user_a_mmr.rating,
+        opponent_rd=user_a_mmr.rating_devi,
+    )
+
+    db.add_all([user_a_log, user_b_log])
+    db.commit()
+    return

--- a/src/app/domain/match/crud/match_crud.py
+++ b/src/app/domain/match/crud/match_crud.py
@@ -12,6 +12,10 @@ async def get_log_by_id(db: Session, input_id: int) -> Optional[MatchLog]:
     return db.query(MatchLog).filter(MatchLog.user_id == input_id, MatchLog.is_consumed.is_(False)).first()
 
 
+async def get_log_by_game_id(db: Session, match_id: int, input_id: int) -> Optional[MatchLog]:
+    return db.query(MatchLog).filter(MatchLog.user_id == input_id, MatchLog.match_id == match_id).first()
+
+
 async def create_match(db: Session, problem_id: int):
     match = Match(problem_id=problem_id, matching_status="created")
     db.add(match)

--- a/src/app/domain/match/service/match_service.py
+++ b/src/app/domain/match/service/match_service.py
@@ -14,7 +14,7 @@ from itertools import count
 
 # 매칭 루프 타이머
 MATCH_INTERVAL = 1  # 초 세팅 0.5 = 500ms
-GO_TO_HARD = 180  # 강제 풀 배치 기준 180 = 180s
+GO_TO_HARD = 15  # 강제 풀 배치 기준 180 = 180s
 match_id_counter = count(1)
 
 
@@ -83,6 +83,7 @@ class MatchService:
                 await self._task
             except asyncio.CancelledError:
                 pass
+
 
 # 되는거
 async def dispatch_pairs(pairs, algo):

--- a/src/app/domain/match/utils/mmr_measure.py
+++ b/src/app/domain/match/utils/mmr_measure.py
@@ -56,7 +56,7 @@ def update_sigma(pie: float, sigma: float, delta: float, v: float) -> float:
         b_result = math.log(square_delta - square_pie - v)
     else:
         k = 1
-        while f(a - k * TAU) > 0:
+        while f(a - k * TAU) < 0:
             k += 1
         b_result = a - (k * TAU)
 

--- a/src/app/domain/user/schemas/user_schemas.py
+++ b/src/app/domain/user/schemas/user_schemas.py
@@ -141,4 +141,4 @@ class UserSignupRequest(BaseModel):
     password: str
     nickname: str
     use_lang: str  # Python, Java, C, C++
-    tier_choice: str  # 브론즈, 실버, 골드, 플래티넘 이상, 티어 없음
+    # tier_choice: str  # 브론즈, 실버, 골드, 플래티넘 이상, 티어 없음

--- a/src/app/models/models.py
+++ b/src/app/models/models.py
@@ -63,9 +63,11 @@ class MatchLog(Base):
     problem_id = Column(Integer, ForeignKey("problem.problem_id"))
     problem = relationship("Problem", back_populates="match_logs")
 
-    result = Column(Enum(MatchResult))
+    result = Column(Enum(MatchResult), nullable=True)
     mmr_earned = Column(Float, default=0)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+    opponent_mmr = Column(Float, nullable=False)
+    opponent_rd = Column(Float, nullable=False)
     is_consumed = Column(Boolean, server_default=text("FALSE"))
 
 


### PR DESCRIPTION
model.py
 -MatchLog 테이블 내 oppenent_mmr 과 rd 를 각각 추가, 이를 MatchLog 생성 함수에도 반영

game_controller.py
 -웹소캣에서 message_type == "match_result": 일 시 reason에 맞춰 경기 결과 반환하는 함수 process_match_result 추가
 
기타
  -경기 종료 후 로그 업데이트 하는 함수 리펙토링

케이스 별 json 내, reason 값(str)
  -클라이언트 -> 서버
    -정답 코드 제출 시 -> finish
    -시간 초과 시 -> timeout
    -탈주 / 항복 시 -> surrender (현재는 동일 처리, abandon / surrender로 구분 가능)

   -서버 -> 클라이언트
      -탈주 / 항복 시 -> surrender
      -제출 했으나 상대가 먼저 제출했을 경우 -> late
      -제출 했고, 성공했을 때 -> finish
      -시간초과 했으나, 상대방이 탈주 / 항복하여 부전승일 시 -> walkover
       -시간초과 했으나, 상대방 또한 마찬가지일 때 -> draw
       -시간초과 했고, 상대방은 이미 제출 완료했을 때 -> late