### PR TITLE
:sparkles: [FEAT] 최근 전적 조회 기능 전체 구현

### DIFF
--- a/src/app/domain/game/router/submit_controller.py
+++ b/src/app/domain/game/router/submit_controller.py
@@ -1,12 +1,16 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from sse_starlette.sse import EventSourceResponse
 from src.app.domain.game.schemas import game_schemas as schemas
 from src.app.domain.game.service import game_service as service
+from sqlalchemy.orm import Session
+from src.app.core.database import get_db
+from src.app.core.security import get_current_user
+from src.app.models.models import User
 
 router = APIRouter()
 
 
 @router.post("/submit")
-async def submit_code(request: schemas.SubmitRequest):
-    event_generator = service.stream_evaluate_code(request.language, request.code, request.problem_id)
+async def submit_code(request: schemas.SubmitRequest, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    event_generator = service.stream_evaluate_code(db, current_user.user_id, request.match_id, request.language, request.code, request.problem_id)
     return EventSourceResponse(event_generator)

--- a/src/app/domain/game/schemas/game_schemas.py
+++ b/src/app/domain/game/schemas/game_schemas.py
@@ -6,6 +6,7 @@ class SubmitRequest(BaseModel):
     language: str
     code: str
     problem_id: str
+    match_id: int
 
 
 class SubmitResponse(BaseModel):

--- a/src/app/domain/game/service/game_result_service.py
+++ b/src/app/domain/game/service/game_result_service.py
@@ -15,9 +15,9 @@ RESULT_TO_SCORE = {
 }
 
 
-async def update_user_mmr(db: Session, user_id: int) -> None:
+async def update_user_mmr(db: Session, game_id: int, user_id: int) -> None:
     user_mmr_info = await get_mmr_by_id(db, user_id)
-    match_log = await get_log_by_id(db, user_id)
+    match_log = await get_log_by_game_id(db, game_id, user_id)
 
     user_rank = await get_rank_by_id(db, user_id)
     if not user_rank:
@@ -56,7 +56,7 @@ async def update_user_mmr(db: Session, user_id: int) -> None:
 
 async def update_user_log(db: Session, game_id: int, user_id: int, result: str) -> None:
     # MatchLog 가져오기
-    user_log = await get_log_by_id(db, user_id)
+    user_log = await get_log_by_game_id(db, game_id, user_id)
 
     # 결과 기록
     if result == "win":
@@ -71,8 +71,9 @@ async def update_user_log(db: Session, game_id: int, user_id: int, result: str) 
     else:
         raise ValueError(f"Invalid result '{result}' passed to update_user_log.")
     db.commit()
+    db.refresh(user_log)
 
-    return await update_user_mmr(db, user_id)
+    return await update_user_mmr(db, game_id, user_id)
 
 
 async def update_match(db: Session, match_id: int, reason: str) -> None:

--- a/src/app/domain/match/crud/match_crud.py
+++ b/src/app/domain/match/crud/match_crud.py
@@ -49,3 +49,7 @@ async def create_match_logs(db: Session, match_id: int, user_ids: list[int], pro
     db.add_all([user_a_log, user_b_log])
     db.commit()
     return
+
+
+async def get_match_logs_by_user_id(db: Session, user_id: int):
+    return db.query(MatchLog).filter(MatchLog.user_id == user_id).order_by(MatchLog.created_at.desc()).all()

--- a/src/app/domain/match/router/match_controller.py
+++ b/src/app/domain/match/router/match_controller.py
@@ -9,6 +9,8 @@ from src.app.domain.match.utils.queues import enqueue_user, dequeue_user, queue_
 from src.app.domain.match.service import match_service as service
 from src.app.domain.user.service.user_service import get_user_data
 from src.app.models.models import Problem
+from src.app.domain.match.schemas import match_schemas as schemas
+
 router = APIRouter()
 DB = Annotated[Session, Depends(get_db)]
 
@@ -129,3 +131,10 @@ async def match_cancel(user_id: int):
         queue_lock.release()
 
     return {"ok": True}
+
+
+@router.get("/match_logs/{user_id}", response_model=list[schemas.MatchLogSchema])
+async def get_user_match_logs(user_id: int, db: DB):
+    match_logs = await service.get_match_logs_by_user_id(db, user_id)
+    return match_logs
+

--- a/src/app/domain/match/schemas/match_schemas.py
+++ b/src/app/domain/match/schemas/match_schemas.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 from dataclasses import dataclass
+from typing import Optional
+from pydantic import BaseModel
+from src.app.models.models import MatchResult
 
 
 @dataclass
@@ -8,3 +11,16 @@ class MatchingUserInfo:
     mmr: float
     rd: float
     joined_at: datetime
+
+
+class MatchLogSchema(BaseModel):
+    match_log_id: int
+    match_id: int
+    problem_id: int
+    result: Optional[MatchResult]
+    mmr_earned: float
+    opponent_mmr: float
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/src/app/domain/match/service/match_service.py
+++ b/src/app/domain/match/service/match_service.py
@@ -131,4 +131,8 @@ async def create_match_with_logs(db: Session, user_ids: list[int]) -> tuple[Matc
     return match, problem.problem_id
 
 
+async def get_match_logs_by_user_id(db: Session, user_id: int):
+    return await match_crud.get_match_logs_by_user_id(db, user_id)
+
+
 match_service = MatchService()


### PR DESCRIPTION
🔸 game_service.py
WebSocket 통신 종료 후 final 메시지 수신 시 result 파싱 → 전적 자동 업데이트 처리

🔸 match_controller.py
GET /match_logs/{user_id}: 특정 유저의 매치 로그 조회 API 추가

🔸 match_crud.py
get_match_logs_by_user_id: 사용자 ID 기준으로 최근 전적 목록 조회 (최신순 정렬)

🔸 match_schemas.py
MatchLogSchema 스키마 추가
→ match_log_id, match_id, problem_id, result, mmr_earned, opponent_mmr, created_at 필드 포함

🔸 match_service.py
get_match_logs_by_user_id: CRUD 호출 및 결과 가공 후 반환

🔸 submit_controller.py
get_current_user, get_db, User import 추가 (전적 기능 연동을 위한 의존성 준비)

✅ 테스트용 시뮬레이션 API 및 관련 함수는 기능 검증 완료 후 제거 처리함