### PR TITLE
:recycle: 인증 쿠키 옵션 개선 (`samesite`, `domain`)

### DIFF
--- a/src/app/domain/auth/router/auth_controller.py
+++ b/src/app/domain/auth/router/auth_controller.py
@@ -31,7 +31,8 @@ async def sign_up(sign_up_request: schemas.SignupRequest, db: DB, response: Resp
             httponly=True,
             max_age=60 * 60 * 24,
             secure=settings.ENV != "local",
-            samesite="lax",
+            samesite="none" if settings.ENV != "local" else "lax",
+            domain=".code-ground.com" if settings.ENV != "local" else None,
         )
 
         return schemas.TokenResponse(access_token=access_token, token_type="bearer")
@@ -61,7 +62,8 @@ async def login(
             httponly=True,
             max_age=60 * 60 * 24,
             secure=settings.ENV != "local",
-            samesite="lax",
+            samesite="none" if settings.ENV != "local" else "lax",
+            domain=".code-ground.com" if settings.ENV != "local" else None,
         )
 
         return {"access_token": access_token, "token_type": "bearer"}


### PR DESCRIPTION
- 환경별로 `samesite`를 `none` 또는 `lax`로 설정하도록 변경
- 로컬이 아닌 경우 `.code-ground.com` 도메인을 쿠키에 추가