### PR TITLE
:recycle: 쿠키 옵션 분리 함수 추가 및 설정 로직 간소화

### DIFF
--- a/src/app/domain/auth/router/auth_controller.py
+++ b/src/app/domain/auth/router/auth_controller.py
@@ -15,6 +15,14 @@ router = APIRouter()
 
 DB = Annotated[Session, Depends(get_db)]
 
+def get_cookie_options():
+    if settings.ENV == "local":
+        # 개발환경: 크로스도메인 문제 없으므로 lax, secure X
+        return False, "lax", None
+    else:
+        # 운영/배포환경: cross-site 인증, https 강제
+        return True, "none", ".code-ground.com"
+
 @router.post("/sign-up")
 async def sign_up(sign_up_request: schemas.SignupRequest, db: DB, response: Response):
     try:
@@ -25,14 +33,16 @@ async def sign_up(sign_up_request: schemas.SignupRequest, db: DB, response: Resp
 
         access_token = create_access_token(subject=str(sign_up_request.email))
 
+        # 환경에 따라 쿠키 옵션 분기 (가독성 및 실수 방지)
+        secure, samesite, domain = get_cookie_options()
         response.set_cookie(
             key="access_token",
             value=access_token,
             httponly=True,
             max_age=60 * 60 * 24,
-            secure=settings.ENV != "local",
-            samesite="none" if settings.ENV != "local" else "lax",
-            domain=".code-ground.com" if settings.ENV != "local" else None,
+            secure=secure,
+            samesite=samesite,
+            domain=domain,
         )
 
         return schemas.TokenResponse(access_token=access_token, token_type="bearer")
@@ -56,14 +66,16 @@ async def login(
         user = await service.authenticate_user(db, form_data.username, form_data.password)
         access_token = create_access_token(subject=user.email)
 
+        # 환경에 따라 쿠키 옵션 분기 (가독성 및 실수 방지)
+        secure, samesite, domain = get_cookie_options()
         response.set_cookie(
             key="access_token",
             value=access_token,
             httponly=True,
             max_age=60 * 60 * 24,
-            secure=settings.ENV != "local",
-            samesite="none" if settings.ENV != "local" else "lax",
-            domain=".code-ground.com" if settings.ENV != "local" else None,
+            secure=secure,
+            samesite=samesite,
+            domain=domain,
         )
 
         return {"access_token": access_token, "token_type": "bearer"}


### PR DESCRIPTION
- `get_cookie_options` 함수로 `samesite`, `secure`, `domain` 설정 분리
- 환경별 쿠키 옵션 처리 가독성 및 유지보수성 개선