### PR TITLE
:recycle: [REFACTOR] CORS 로직 및 요청 유효성 검사 예외 처리 추가

### DIFF
--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -38,10 +38,7 @@ class Settings(BaseSettings):
         env = (getattr(self, "ENV", None) or getattr(self, "ENVIRONMENT", None) or "local").lower()
         if env in ["local"]:
             # 개발환경: 환경변수에서 값을 받아오되 없으면 "*"로 모두 허용
-            raw = os.environ.get("CORS_ALLOWED_ORIGINS", "*")
-            if raw == "*":
-                return ["*"]
-            return [o.strip() for o in raw.split(",") if o.strip()]
+            return ["http://localhost:8080"]
         elif env in ["dev", "DEV"]:
             # 운영/배포환경: 환경변수에서 반드시 허용할 도메인만 리스트로 반환
             raw = os.environ.get("CORS_ALLOWED_ORIGINS", "https://code-ground.com")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -2,6 +2,7 @@ import uvicorn
 from pathlib import Path
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
@@ -33,6 +34,15 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    print(f"🚨 Validation error on {request.url}: {exc.errors()}")
+    print(f"🚨 Body: {await request.body()}")
+    return JSONResponse(
+        status_code=400,
+        content={"detail": exc.errors()},
+    )
 
 # 미들웨어 등록
 app.add_middleware(DomainLimiterMiddleware)


### PR DESCRIPTION
- 로컬 환경에서 CORS 기본 허용 도메인을 `http://localhost:8080`으로 변경
- `RequestValidationError` 예외 핸들러 추가로 요청 유효성 검사 오류에 대한 응답 처리 개선