### PR TITLE
🐛 [FIX] image_key가 NULL일 경우의 예외 핸들링

### DIFF
--- a/src/app/domain/match/router/match_controller.py
+++ b/src/app/domain/match/router/match_controller.py
@@ -91,6 +91,8 @@ async def handle_accept(match_id: int, user_id: int, db: Session):
             user_cache.pop(uid, None)
         game_user_map[match.match_id] = users
 
+        print(f"[DEBUG] match_id: {match.match_id}, users: {users}, problem: {problem.problem_id}, difficulty: {problem.difficulty}")
+
         presigned = await issue_problem_urls(problem)
 
         msg = {

--- a/src/app/utils/s3_utils.py
+++ b/src/app/utils/s3_utils.py
@@ -34,11 +34,19 @@ async def issue_problem_urls(problem : Problem) -> ProblemURLBundle:
     if problem is None:
         raise ValueError("Problem 객체가 없습니다")
 
+    print(f"[DEBUG] issue_problem_urls: {problem.problem_id}, body_key: {problem.body_key}, image_keys: {problem.image_keys}")
     #문제 본문 url
     problem_url = sign_s3_url(problem.body_key, ttl=ENDTIMER)
 
     #이미지 url
     image_urls: list[str] = []
+    if not problem.image_keys:
+        print(f"[DEBUG] 문제 {problem.problem_id}에 이미지가 없습니다.")
+        return {
+            "problem_url": problem_url,
+            "image_urls": image_urls
+        }
+    
     for key in problem.image_keys:                  # TEXT[] 순서를 그대로 유지
         url = sign_s3_url(key, ttl=ENDTIMER)
         image_urls.append(url)


### PR DESCRIPTION
제목과 내용이 동일합니다.

- `Problem` 테이블의 해당 문제의 `image_key`가 `NULL`일 경우 예외 핸들링
  - 게임 큐 잡은 뒤 매칭 시도 시, 이전에는 아래와 같은 예외가 발생하며 매칭이 진행되지 않았으나, 해당 픽스를 통해 매칭이 진행됩니다.
  
```
  File "/Codeground-Backend-2/src/app/utils/s3_utils.py", line 43, in issue_problem_urls
    for key in problem.image_keys:                  # TEXT[] 순서를 그대로 유지
 ```