### PR TITLE
:sparkles: [FEAT] GitHub 소셜 로그인 전체 기능 구현

### DIFF
--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -24,8 +24,13 @@ class Settings(BaseSettings):
     DB_PASSWORD: str = os.environ.get("DB_PASSWORD", "")
     DB_NAME: str = os.environ.get("DB_NAME", "")
     ONLINE_JUDGE_HOST_ENDPOINT: str = os.environ.get("ONLINE_JUDGE_HOST_ENDPOINT", "")
-    PROBLEM_BUCKET: str = os.environ.get("PROBLEM_BUCKET", "" )
-    AWS_REGION: str = os.environ.get("AWS_REGION","" )
+    PROBLEM_BUCKET: str = os.environ.get("PROBLEM_BUCKET", "")
+    AWS_REGION: str = os.environ.get("AWS_REGION", "")
+    AWS_ACCESS_KEY_ID: str = os.environ.get("AWS_ACCESS_KEY_ID", "")
+    AWS_SECRET_ACCESS_KEY: str = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+    GITHUB_CLIENT_ID: str = os.environ.get("GITHUB_CLIENT_ID", "")
+    GITHUB_CLIENT_SECRET: str = os.environ.get("GITHUB_CLIENT_SECRET", "")
+    FRONTEND_REDIRECT_URL: str = os.environ.get("FRONTEND_REDIRECT_URL", "http://localhost:8080/oauth/callback")
 
     class Config:
         env_file = ENV_PATH
@@ -46,5 +51,6 @@ class Settings(BaseSettings):
             # 운영/배포환경: 환경변수에서 반드시 허용할 도메인만 리스트로 반환
             raw = os.environ.get("CORS_ALLOWED_ORIGINS", "https://code-ground.com")
             return [o.strip() for o in raw.split(",") if o.strip()]
+
 
 settings = Settings()

--- a/src/app/domain/auth/__init__.py
+++ b/src/app/domain/auth/__init__.py
@@ -2,4 +2,4 @@ from fastapi import APIRouter
 from .router import auth_controller
 
 router = APIRouter()
-router.include_router(auth_controller.router, prefix="/auth", tags=["auth"])
+router.include_router(auth_controller.router, tags=["auth"])

--- a/src/app/domain/auth/crud/auth_crud.py
+++ b/src/app/domain/auth/crud/auth_crud.py
@@ -34,3 +34,27 @@ def join_user(db: Session, sign_up_request: schemas.SignupRequest, mmr: int, use
     db.add(mmr_row)
 
     return new_user
+
+
+def get_user_by_github_id(db: Session, github_id: str) -> Optional[User]:
+    return db.query(User).filter(User.github_id == github_id).first()
+
+
+def create_social_user(db: Session, user_data: schemas.SocialSignupRequest) -> User:
+    new_user = User(
+        email=str(user_data.email),
+        username=user_data.username,
+        nickname=user_data.nickname,
+        role=UserRole.USER,
+        github_id=user_data.github_id,
+        profile_img_url=user_data.profile_img_url,
+    )
+    db.add(new_user)
+    db.flush()
+
+    mmr_row = UserMmr(user_id=new_user.user_id, rating=1000)
+    db.add(mmr_row)
+    db.commit()
+    db.refresh(new_user)
+
+    return new_user

--- a/src/app/domain/auth/router/auth_controller.py
+++ b/src/app/domain/auth/router/auth_controller.py
@@ -11,7 +11,7 @@ from src.app.domain.auth.service import auth_service as service
 from src.app.core.token import create_access_token
 from src.app.domain.auth.crud import auth_crud as crud
 
-router = APIRouter()
+router = APIRouter(prefix="/auth")
 
 DB = Annotated[Session, Depends(get_db)]
 
@@ -23,6 +23,25 @@ def get_cookie_options():
     else:
         # 운영/배포환경: cross-site 인증, https 강제
         return True, "none", ".code-ground.com", True
+
+
+def set_access_token_cookie(response: Response, access_token: str):
+    secure, samesite, domain, http_only = get_cookie_options()
+
+    cookie_params = {
+        "key": "access_token",
+        "value": access_token,
+        "httponly": http_only,
+        "max_age": 60 * 60 * 24,
+        "secure": secure,
+        "samesite": samesite,
+        "path": "/",
+    }
+
+    if domain:
+        cookie_params["domain"] = domain
+
+    response.set_cookie(**cookie_params)
 
 
 @router.post("/sign-up")
@@ -61,9 +80,9 @@ async def sign_up(sign_up_request: schemas.SignupRequest, db: DB, response: Resp
 
 @router.post("/login")
 async def login(
-        db: DB,
-        response: Response,
-        form_data: OAuth2PasswordRequestForm = Depends(),
+    db: DB,
+    response: Response,
+    form_data: OAuth2PasswordRequestForm = Depends(),
 ):
     try:
         user = await service.authenticate_user(db, form_data.username, form_data.password)

--- a/src/app/domain/auth/router/github_controller.py
+++ b/src/app/domain/auth/router/github_controller.py
@@ -1,0 +1,51 @@
+from typing import Annotated
+from fastapi import APIRouter, Depends
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from src.app.core.database import get_db
+from src.app.core.token import create_access_token
+from src.app.domain.auth.service.github_service import get_github_auth_url, handle_github_callback
+from src.app.config.config import settings
+from src.app.domain.auth.router.auth_controller import get_cookie_options
+
+router = APIRouter(prefix="/auth/github")
+
+DB = Annotated[Session, Depends(get_db)]
+
+
+@router.get("/login")  # ✅ 이렇게 수정
+async def github_login():
+    redirect_url = get_github_auth_url()
+    return RedirectResponse(url=redirect_url, status_code=302)
+
+
+@router.get("/callback")
+async def github_callback(code: str, db: DB):
+    result = await handle_github_callback(code, db)
+
+    # 👉 이메일 중복 등으로 RedirectResponse가 반환된 경우
+    if isinstance(result, RedirectResponse):
+        return result
+
+    user, is_new_user = result
+    access_token = create_access_token(subject=user.email)
+
+    redirect_url = f"{settings.FRONTEND_REDIRECT_URL}?new_user={str(is_new_user).lower()}"
+    response = RedirectResponse(url=redirect_url, status_code=302)
+
+    secure, samesite, domain, http_only = get_cookie_options()
+    print("🍪 쿠키 옵션:", secure, samesite, domain, http_only)
+
+    response.set_cookie(
+        key="access_token",
+        value=access_token,
+        httponly=http_only,
+        secure=secure,
+        samesite=samesite,
+        path="/",
+        max_age=60 * 60 * 24,
+        domain=domain,
+    )
+
+    return response

--- a/src/app/domain/auth/schemas/auth_schemas.py
+++ b/src/app/domain/auth/schemas/auth_schemas.py
@@ -32,3 +32,11 @@ class LoginUserDto(BaseModel):
     nickname: str
 
     model_config = {"from_attributes": True}
+
+
+class SocialSignupRequest(BaseModel):
+    email: EmailStr
+    username: str
+    nickname: str
+    github_id: str
+    profile_img_url: Optional[str] = None

--- a/src/app/domain/auth/service/auth_service.py
+++ b/src/app/domain/auth/service/auth_service.py
@@ -34,11 +34,27 @@ async def join(db: Session, sign_up_request: schemas.SignupRequest) -> schemas.S
 
 
 async def authenticate_user(db: Session, email: str, password: str) -> schemas.LoginUserDto:
-    user = crud.get_user_by_email(db, email)  # ✅ await 제거
-    if not user or not await verify_password(password, user.password):
+    user = crud.get_user_by_email(db, email)
+
+    if not user:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="이메일 또는 비밀번호가 올바르지 않습니다."
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="이메일 또는 비밀번호가 올바르지 않습니다.",
         )
+
+    # ✅ GitHub 로그인 계정이면 비밀번호가 없음
+    if user.github_id and not user.password:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="이 이메일은 GitHub 계정으로 가입되었습니다. GitHub 로그인으로 이용해주세요.",
+        )
+
+    if not await verify_password(password, user.password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="이메일 또는 비밀번호가 올바르지 않습니다.",
+        )
+
     return schemas.LoginUserDto.model_validate(user)
 
 

--- a/src/app/domain/auth/service/github_service.py
+++ b/src/app/domain/auth/service/github_service.py
@@ -1,0 +1,103 @@
+import httpx
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from src.app.config.config import settings
+from src.app.domain.auth.schemas import auth_schemas as schemas
+from src.app.domain.auth.crud import auth_crud as crud
+from fastapi.responses import RedirectResponse
+from urllib.parse import urlencode
+
+
+def get_github_auth_url() -> str:
+    redirect_uri = "http://localhost:8000/api/v1/auth/github/callback"  # ✅ 백엔드 콜백 주소
+    print("🔑 GitHub Client ID:", settings.GITHUB_CLIENT_ID)  # ✅ 여기 추가
+    return (
+        "https://github.com/login/oauth/authorize"
+        f"?client_id={settings.GITHUB_CLIENT_ID}"
+        "&scope=read:user user:email"
+        f"&redirect_uri={redirect_uri}"
+    )
+
+
+async def handle_github_callback(code: str, db: Session):
+    async with httpx.AsyncClient() as client:
+        # 1. access token 요청
+        token_response = await client.post(
+            "https://github.com/login/oauth/access_token",
+            data={
+                "client_id": settings.GITHUB_CLIENT_ID,
+                "client_secret": settings.GITHUB_CLIENT_SECRET,
+                "code": code,
+            },
+            headers={"Accept": "application/json"},
+        )
+
+        token_data = token_response.json()
+        access_token = token_data.get("access_token")
+
+        if not access_token:
+            raise HTTPException(status_code=400, detail="GitHub access token 발급 실패")
+
+        # 2. 유저 기본 정보 요청
+        user_response = await client.get(
+            "https://api.github.com/user",
+            headers={"Authorization": f"token {access_token}", "Accept": "application/json"},
+        )
+        github_user_data = user_response.json()
+        github_id = str(github_user_data.get("id"))
+        email = github_user_data.get("email")
+        nickname = github_user_data.get("login")
+        profile_img_url = github_user_data.get("avatar_url")
+
+        # 3. 이메일이 없을 경우 보조 API로 조회
+        if not email:
+            user_emails_response = await client.get(
+                "https://api.github.com/user/emails",
+                headers={"Authorization": f"token {access_token}", "Accept": "application/json"},
+            )
+
+            if user_emails_response.status_code != 200:
+                raise HTTPException(status_code=400, detail="GitHub 이메일 정보를 가져오지 못했습니다")
+
+            emails_data = user_emails_response.json()
+            if not isinstance(emails_data, list):
+                raise HTTPException(status_code=400, detail="GitHub 이메일 응답 형식이 잘못되었습니다")
+
+            primary_email = next((e for e in emails_data if isinstance(e, dict) and e.get("primary")), None)
+            if primary_email:
+                email = primary_email.get("email")
+
+        if not email:
+            raise HTTPException(status_code=400, detail="GitHub에서 이메일을 확인할 수 없습니다.")
+
+        # ✅ 4. github_id 기준으로만 사용자 조회
+        is_new_user = False
+        user = crud.get_user_by_github_id(db, github_id)
+        if user:
+            return user, is_new_user
+
+        # ✅ 5. 이메일 중복 계정이 있을 경우 오류 반환
+        existing_user = crud.get_user_by_email(db, email)
+        if existing_user:
+            query_params = urlencode({
+                "message": (
+                    "이미 가입된 이메일로 등록된 계정이 있습니다. 일반 로그인 또는 다른 GitHub 계정을 사용해주세요."
+                )
+            })
+            return RedirectResponse(
+                url=f"{settings.FRONTEND_REDIRECT_URL.replace('/oauth/callback', '/login')}?{query_params}",
+                status_code=302,
+            )
+
+        # 6. 신규 유저 생성
+        is_new_user = True
+        new_user_data = schemas.SocialSignupRequest(
+            email=email,
+            nickname=nickname,
+            github_id=github_id,
+            profile_img_url=profile_img_url,
+            username=github_user_data.get("name") or nickname,
+        )
+        new_user = crud.create_social_user(db, new_user_data)
+        return new_user, is_new_user

--- a/src/app/domain/match/service/match_service.py
+++ b/src/app/domain/match/service/match_service.py
@@ -126,7 +126,7 @@ async def handle_match_timeout(match_id: int, users: list[int], timeout: int):
 async def create_match_with_logs(db: Session, user_ids: list[int]) -> tuple[Match, Problem]:
     mmrs = [get_user_mmr(db, uid) for uid in user_ids]
     tiers = [mmr_to_tier(mmr) for mmr in mmrs]
-    problem = await select_problem_for_tiers(db, tiers[0], tiers[1]) # 티어에 맞춰 랜덤 문제 반환
+    problem = await select_problem_for_tiers(db, tiers[0], tiers[1])  # 티어에 맞춰 랜덤 문제 반환
     match = await match_crud.create_match(db, problem.problem_id)
     await match_crud.create_match_logs(db, match.match_id, user_ids, problem.problem_id)
     db.commit()
@@ -138,7 +138,7 @@ async def get_match_logs_by_user_id(db: Session, user_id: int, counts: int):
 
     logs = await match_crud.get_match_log_by_user_index(db, user_id, counts)
     if not logs:
-        return None
+        return []
 
     for log in logs:
         problem_id = log.problem_id
@@ -151,7 +151,15 @@ async def get_match_logs_by_user_id(db: Session, user_id: int, counts: int):
         difficultly = str(game.difficulty.value)
         earned = int(log.mmr_earned)
         title = str(game.title)
-        result = MatchLogSchema( result = result, mmr_earned = earned,opponent_name = opponent_nick ,opponent_tier = opponent_tier, game_difficulty = difficultly, game_time = game_time, game_title=title )
+        result = MatchLogSchema(
+            result=result,
+            mmr_earned=earned,
+            opponent_name=opponent_nick,
+            opponent_tier=opponent_tier,
+            game_difficulty=difficultly,
+            game_time=game_time,
+            game_title=title,
+        )
         logs_return_list.append(result)
     return logs_return_list
 

--- a/src/app/domain/user/router/user_controller.py
+++ b/src/app/domain/user/router/user_controller.py
@@ -17,14 +17,12 @@ async def get_user_me(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    print("===== [쿠키 값 출력] =====")
-    print(request.cookies)
-    print("========================")
+
     try:
         user = await service.get_user_data(db, current_user.user_id)
         user_mmr = await get_mmr_by_id(db, user.user_id)
         mmr = user_mmr.rating if user_mmr.rating else 1000
-        user_rank_info = await  get_rank_by_id(db, user.user_id)
+        user_rank_info = await get_rank_by_id(db, user.user_id)
         user_rank = user_rank_info.rank if user_rank_info else 00
         user_dict = user.model_dump()
         user_dict["user_mmr"] = int(mmr)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -16,8 +16,8 @@ from src.app.domain.report import router as report_router
 from src.app.config.config import settings
 from src.app.domain.match.service.match_service import match_service
 from src.app.domain.ranking.router.ranking_controller import router as ranking_router
+from src.app.domain.auth.router.github_controller import router as github_router
 from src.app.domain.ranking.service.ranking_scheduler import start_ranking_scheduler
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from src.app.utils.middlewares.domain_limiter import DomainLimiterMiddleware
 
@@ -35,6 +35,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     print(f"🚨 Validation error on {request.url}: {exc.errors()}")
@@ -43,6 +44,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         status_code=400,
         content={"detail": exc.errors()},
     )
+
 
 # 미들웨어 등록
 app.add_middleware(DomainLimiterMiddleware)
@@ -58,6 +60,7 @@ app.add_middleware(
 )
 
 app.include_router(router=auth_router, prefix=settings.API_V1_STR)
+app.include_router(router=github_router, prefix=settings.API_V1_STR)  # ✅ 명확히 분리
 app.include_router(router=webrtc_router, prefix=settings.API_V1_STR)
 app.include_router(router=match_router, prefix=settings.API_V1_STR)
 app.include_router(router=user_router, prefix=settings.API_V1_STR)
@@ -70,6 +73,7 @@ app.include_router(router=report_router, prefix=settings.API_V1_STR)
 @app.get("/")
 async def health_check():
     return JSONResponse({"status": "ok"})
+
 
 # test
 if __name__ == "__main__":

--- a/src/app/models/models.py
+++ b/src/app/models/models.py
@@ -15,7 +15,8 @@ class User(Base):
 
     user_id = Column(Integer, primary_key=True, autoincrement=True)
     email = Column(String(255), unique=True, nullable=False)
-    password = Column(String(255), nullable=False)
+    password = Column(String(255), nullable=True)
+    github_id = Column(String(255), unique=True, nullable=True)
     use_lang = Column(String(50), nullable=False, server_default="python3")  # 사용언어
     username = Column(String(255), nullable=False)
     nickname = Column(String(255), unique=True, nullable=False)
@@ -120,7 +121,7 @@ class Problem(Base):
     category = Column(ARRAY(String), nullable=False)
     difficulty = Column(Enum(ProblemDifficultyByTiers), nullable=True)
     body_key = Column(Text, nullable=False)
-    image_keys = Column(ARRAY(Text),nullable=True, default=list)
+    image_keys = Column(ARRAY(Text), nullable=True, default=list)
     language = Column(ARRAY(String), nullable=False)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
@@ -138,7 +139,7 @@ class Ranking(Base):
 
     ranking_id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(Integer, ForeignKey("users.user_id"), nullable=False)
-    mmr = Column(Integer, nullable=False,index = True)
+    mmr = Column(Integer, nullable=False, index=True)
     language = Column(String, nullable=False, server_default="python3")
     rank = Column(Integer, nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())


### PR DESCRIPTION
🔸 github_service.py
- GitHub OAuth flow 전반 처리: /login → /callback
- get_github_auth_url: GitHub 인증 요청 URL 생성
- handle_github_callback:
  - access_token 요청 및 user 정보 파싱
  - email 없을 시 별도 이메일 API 호출
  - github_id 기준 기존 유저 조회, 없으면 신규 생성
  - is_new_user 플래그로 신규 여부 구분
  - ⚠️ 일반 로그인에 이미 사용 중인 이메일일 경우: → 로그인 중단 및 프론트엔드 `/login`으로 리디렉션 → `이미 가입된 이메일입니다. 일반 로그인 또는 다른 GitHub 계정을 이용해주세요.` 경고 메시지 전달

🔸 auth_crud.py
- get_user_by_github_id: github_id 기준 유저 조회
- create_social_user: GitHub 로그인 전용 계정 생성 → email + github_id 함께 저장 → 일반 계정과 이메일이 겹쳐도 새 유저로 간주

🔸 auth_controller.py / github_controller.py
- /auth/github/login: GitHub 로그인 URL 반환
- /auth/github/callback: GitHub 인증 후 로그인 처리, 쿠키 발급 및 프론트 리디렉션

🔸 auth_schemas.py
- SocialSignupRequest: GitHub 계정으로 회원가입할 때 필요한 정보(email, github_id 등) 담는 스키마 추가

🔸 기타
- 기존 이메일 중복 검사 로직에서 GitHub 계정 제외 처리
- GitHub 소셜 로그인 사용자와 일반 로그인 사용자 명확히 구분되도록 설계 → 동일 이메일이어도 login 방식이 다르면 서로 다른 유저로 처리됨

✅ 로컬 테스트 및 GitHub 신규 계정/기존 계정 로그인 검증 완료
✅ 기존 일반 계정과 충돌 시 정상 차단 및 메시지 안내 확인