### PR TITLE
✨ [FEAT] POST /submit_public 구현

### DIFF
--- a/src/app/domain/game/router/submit_controller.py
+++ b/src/app/domain/game/router/submit_controller.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends
-from sse_starlette.sse import EventSourceResponse
+from sse_starlette.sse import EventSourceResponse, AppStatus
 from src.app.domain.game.schemas import game_schemas as schemas
 from src.app.domain.game.service import game_service as service
 from sqlalchemy.orm import Session
@@ -12,5 +12,21 @@ router = APIRouter()
 
 @router.post("/submit")
 async def submit_code(request: schemas.SubmitRequest, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    """
+    전체 테스트케이스들에 대하여 채점. 전체 정답일 경우 승리 판정하는 로직을 추가해야 할지도?
+    """
+    AppStatus.should_exit_event = None # 여기서 AppStatus는, EventSourceResponse와 관련된 이벤트 스트리밍 처리에서, 서버 상태나 종료 신호(should_exit_event 등)를 관리하는 데 쓰임.
+    # 코드에서 위 값(should_exit_event)을 명시적으로 None으로 리셋하는 이유는, 이전에 남아있던 종료 플래그를 초기화함으로써 새로운 SSE 세션에 영향이 없도록 하기 위함임.
     event_generator = service.stream_evaluate_code(db, current_user.user_id, request.match_id, request.language, request.code, request.problem_id)
+    return EventSourceResponse(event_generator)
+
+@router.post("/submit_public")
+async def submit_code_public(request: schemas.SubmitRequest):
+    """
+    visiblity가 public인 테스트케이스들에 대하여 채점.
+    """
+    AppStatus.should_exit_event = None
+    event_generator = service.stream_evaluate_code_public(
+        request.language, request.code, request.problem_id
+    )
     return EventSourceResponse(event_generator)

--- a/src/app/domain/game/service/game_service.py
+++ b/src/app/domain/game/service/game_service.py
@@ -72,3 +72,40 @@ async def stream_evaluate_code(db: Session, user_id: int, match_id: int, languag
                 if result:
                     await game_result_service.update_user_log(db, match_id, user_id, result)
                 break
+
+async def stream_evaluate_code_public(language: str, code: str, problem_id: str):
+    """Submit code to the judge service using /execute_v4_public and stream results.
+
+    This mirrors :func:`stream_evaluate_code` but only evaluates against public
+    test cases. It yields raw JSON strings received from the judge backend
+    websocket until a final message is sent.
+    """
+
+    base_url = settings.ONLINE_JUDGE_HOST_ENDPOINT.rsplit("/", 1)[0]
+    execute_url = f"{base_url}/execute_v4_public"
+    payload = {
+        "language": language,
+        "code": code,
+        "problemId": problem_id,
+        "token": None,
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(execute_url, json=payload)
+            response.raise_for_status()
+            request_id = response.json().get("requestId")
+        except httpx.HTTPStatusError as e:
+            raise HTTPException(status_code=e.response.status_code, detail="Judge request failed")
+        except httpx.HTTPError:
+            raise HTTPException(status_code=500, detail="Judge service unreachable")
+
+    scheme, rest = execute_url.split("://", 1)
+    ws_scheme = "wss" if scheme == "https" else "ws"
+    ws_url = f"{ws_scheme}://{rest.split('/')[0]}/ws/progress/{request_id}"
+
+    async with websockets.connect(ws_url) as websocket:  # type: ignore[attr-defined]
+        async for message in websocket:
+            yield message
+            if '"type":"final"' in message or '"type": "final"' in message:
+                break

--- a/test/app/domain/game/router/test_submit_controller.py
+++ b/test/app/domain/game/router/test_submit_controller.py
@@ -20,3 +20,20 @@ def test_submit_stream(mock_stream):
     assert 'data: {"type": "progress"}' == body[0]
     assert 'data: {"type": "final"}' == body[2]
     mock_stream.assert_called_once_with("python", "print('hi')", "prob-001")
+
+
+@patch("src.app.domain.game.service.game_service.stream_evaluate_code_public")
+def test_submit_public_stream(mock_stream):
+    async def gen():
+        yield '{"type": "progress"}'
+        yield '{"type": "final"}'
+
+    mock_stream.return_value = gen()
+    data = {"language": "python", "code": "print('hi')", "problem_id": "prob-001"}
+    with client.stream("POST", "/api/v1/game/submit_public", json=data) as response:
+        body = list(response.iter_lines())
+
+    assert response.status_code == 200
+    assert 'data: {"type": "progress"}' == body[0]
+    assert 'data: {"type": "final"}' == body[2]
+    mock_stream.assert_called_once_with("python", "print('hi')", "prob-001")


### PR DESCRIPTION
- 기존 `POST /submit`는 해당 문제의 전체 테스트케이스들을 채점합니다. 이번에 추가된 `POST /submit_public`는, 해당 문제의 visibility가 public인 테스트케이스들만 채점합니다.