### PR TITLE
🔧 [UPDATE] ECS Task Definition 및 S3 업로드 오류 처리 개선

### DIFF
--- a/.aws/ecs-task-definition.json
+++ b/.aws/ecs-task-definition.json
@@ -33,6 +33,10 @@
                 {
                     "name": "FRONTEND_REDIRECT_URL",
                     "value": "https://code-ground.com"
+                },
+                {
+                    "name": "ONLINE_JUDGE_HOST_ENDPOINT",
+                    "value": "http://10.0.149.45:18651/execute_v4"
                 }
             ],
             "mountPoints": [],

--- a/src/app/domain/auth/service/github_service.py
+++ b/src/app/domain/auth/service/github_service.py
@@ -10,8 +10,7 @@ from urllib.parse import urlencode
 
 
 def get_github_auth_url() -> str:
-    redirect_uri = "http://localhost:8000/api/v1/auth/github/callback"  # ✅ 백엔드 콜백 주소
-    print("🔑 GitHub Client ID:", settings.GITHUB_CLIENT_ID)  # ✅ 여기 추가
+    redirect_uri = "http://localhost:8000/api/v1/auth/github/callback"
     return (
         "https://github.com/login/oauth/authorize"
         f"?client_id={settings.GITHUB_CLIENT_ID}"

--- a/src/app/utils/s3_utils.py
+++ b/src/app/utils/s3_utils.py
@@ -39,8 +39,7 @@ def upload_bytes(data: bytes, key: str, bucket: str = REPORT_BUCKET) -> None:
     try:
         s3.put_object(Bucket=bucket, Key=key, Body=data)
     except Exception as e:
-        pass
-        # raise RuntimeError(f"S3 업로드 실패: {key}, 에러: {e}")
+        raise RuntimeError(f"S3 업로드 실패: {key}, 에러: {e}")
 
 
 async def issue_problem_urls(problem: Problem) -> ProblemURLBundle:


### PR DESCRIPTION
- ECS Task Definition에 `ONLINE_JUDGE_HOST_ENDPOINT` 환경 변수 추가
- GitHub 인증 URL 생성 함수에서 불필요한 주석 제거
- S3 업로드 실패 시 예외 처리 로직 수정: 오류 발생 시 RuntimeError로 변경