### PR TITLE
:sparkles: [Feat] 제출 정답 시 즉시 결과 반환 추가 및 match_result 로직 수정

### DIFF
--- a/.aws/ecs-task-definition.json
+++ b/.aws/ecs-task-definition.json
@@ -37,6 +37,10 @@
                 {
                     "name": "ONLINE_JUDGE_HOST_ENDPOINT",
                     "value": "http://10.0.149.45:18651/execute_v4"
+                },
+                {
+                    "name": "REPORT_BUCKET",
+                    "value": "codeground-report"
                 }
             ],
             "mountPoints": [],

--- a/src/app/domain/game/router/game_controller.py
+++ b/src/app/domain/game/router/game_controller.py
@@ -1,8 +1,9 @@
 from fastapi import Depends, WebSocket, WebSocketDisconnect, APIRouter, Query
+from src.app.domain.match.crud.match_crud import get_log_by_game_id
 from src.app.utils.game_session import game_rooms, game_user_map, ready_status, disconnected_users
 import json
 import asyncio
-from src.app.domain.game.service.game_result_service import update_user_log, update_match, search_result, get_mmr_earned
+from src.app.domain.game.service.game_result_service import update_user_log, update_match, get_mmr_earned
 from typing import Annotated
 from sqlalchemy.orm import Session
 from src.app.core.database import get_db
@@ -164,17 +165,7 @@ async def handle_game_message(db, websocket: WebSocket, game_id: int, user_id: i
         # 각 reason 은 "finish" / "timeout" / "surrender"
         elif message_type == "match_result":
             reason = data.get("reason")
-            print("시작")
-            winner_id, reason = await process_match_result(db, game_id, user_id, opponent_id, reason)
-            mmr_earned = await get_mmr_earned(db, game_id, user_id)
-            print(winner_id, reason, mmr_earned)
-
-            await broadcast_to_room(game_id, {
-                "type": "match_result",
-                "winner": winner_id,
-                "earned": mmr_earned,
-                "reason": reason
-            })
+            await process_match_result(db, game_id, user_id, opponent_id, reason)
 
         else:
             print("에러 1")
@@ -205,45 +196,47 @@ async def broadcast_to_room(game_id: int, message: dict, exclude: WebSocket = No
             game_rooms[game_id].remove(ws)
 
 
-async def process_match_result(
-        db: Session, game_id: int, user_id: int, opponent_id: int, reason: str
-) -> (int | None, str):
-    opponent_result = await search_result(db, game_id, opponent_id)
+async def process_match_result(db: Session, game_id: int, user_id: int, opponent_id: int, reason: str) -> None:
+
+    # 동시 적용 시
+    user_log = await get_log_by_game_id(db, game_id, user_id)
+    if user_log.result:
+        return None
+
     # 기권 시
     if reason in ("surrender", "abandon"):
-        await update_user_log(db, game_id, user_id, "loss")
-        if opponent_result and opponent_result == "loss":
-            await update_match(db, game_id, "abnormal")
-        # 패배
-        return opponent_id, "surrender"
+        await update_match(db, game_id, "normal")
+        await update_user_log(db, game_id, user_id, opponent_id, opponent_id)
+
+        winner_id, reason = opponent_id, "surrender"
     # 시간 초과 시
     elif reason == "timeout":
-        # 상대방 상태 판단
-        if opponent_result == "loss":
-            await update_user_log(db, game_id, user_id, "win")
-            await update_match(db, game_id, "abnormal")
-            # 상대 기권 시 부전승
-            return user_id, "walkover"
+        await update_match(db, game_id, "draw")
+        await update_user_log(db, game_id, user_id, opponent_id, None)
+        winner_id, reason = None, "draw"
 
-        elif opponent_result == "win":
-            await update_user_log(db, game_id, user_id, "loss")
-            # 상대가 이미 제출 완료 시 패배
-            return opponent_id, "late"
-
-        else:
-            # 상대 또한 timeout 일 시, 무승부
-            await update_user_log(db, game_id, user_id, "draw")
-            await update_match(db, game_id, "draw")
-            return None, "draw"
-
+    # 승리 시
     else:
-        if opponent_result == "win":
-            await update_user_log(db, game_id, user_id, "loss")
-            return opponent_id, "late"
-        else:
-            await update_user_log(db, game_id, user_id, "win")
-            await update_match(db, game_id, "normal")
-            return user_id, "finish"
+        await update_match(db, game_id, "normal")
+        await update_user_log(db, game_id, user_id, opponent_id, user_id)
+        winner_id, reason = user_id, "finish"
+
+    return await broadcast_result(db, game_id, user_id, opponent_id, winner_id, reason)
+
+
+async def broadcast_result(db : Session, game_id: int, user_id: int, opponent_id: int, winner_id : int | None, reason: str | None) -> None:
+    if reason:
+        user_earned = await get_mmr_earned(db, game_id, user_id)
+        opponent_earned = await get_mmr_earned(db, game_id, opponent_id)
+        await broadcast_to_room(game_id, {
+            "type": "match_result",
+            "winner": winner_id,
+            "plus_mmr": max(user_earned, opponent_earned),
+            "minus_mmr": min(user_earned, opponent_earned),
+            "reason": reason
+        })
+    else:
+        return
 
 
 #로컬용

--- a/src/app/domain/game/router/submit_controller.py
+++ b/src/app/domain/game/router/submit_controller.py
@@ -18,6 +18,7 @@ async def submit_code(request: schemas.SubmitRequest, db: Session = Depends(get_
     AppStatus.should_exit_event = None # 여기서 AppStatus는, EventSourceResponse와 관련된 이벤트 스트리밍 처리에서, 서버 상태나 종료 신호(should_exit_event 등)를 관리하는 데 쓰임.
     # 코드에서 위 값(should_exit_event)을 명시적으로 None으로 리셋하는 이유는, 이전에 남아있던 종료 플래그를 초기화함으로써 새로운 SSE 세션에 영향이 없도록 하기 위함임.
     event_generator = service.stream_evaluate_code(db, current_user.user_id, request.match_id, request.language, request.code, request.problem_id)
+    print(event_generator)
     return EventSourceResponse(event_generator)
 
 @router.post("/submit_public")

--- a/src/app/domain/game/service/game_result_service.py
+++ b/src/app/domain/game/service/game_result_service.py
@@ -1,7 +1,7 @@
 from src.app.domain.match.utils.mmr_measure import full_update, MatchScore
 from src.app.models.models import MatchResult, MatchFinishStatus, MatchStatus
-from src.app.domain.match.crud.match_crud import get_log_by_id, get_mmr_by_id, get_log_by_game_id
-from src.app.domain.ranking.crud.ranking_crud import get_rank_by_id, get_users_in_mmr_range
+from src.app.domain.match.crud.match_crud import get_mmr_by_id, get_log_by_game_id
+from src.app.domain.ranking.crud.ranking_crud import get_rank_by_id
 from src.app.domain.ranking.service.ranking_service import create_rank
 from sqlalchemy.orm import Session
 from src.app.models.models import Match
@@ -83,26 +83,30 @@ async def update_user_mmr(db: Session, game_id: int, user_id: int) -> None:
     return
 
 
-async def update_user_log(db: Session, game_id: int, user_id: int, result: str) -> None:
+async def update_user_log(db: Session, game_id: int, user_id: int, opponent_id : int, winner_id: int | None) -> None:
     # MatchLog 가져오기
     user_log = await get_log_by_game_id(db, game_id, user_id)
-
+    opponent_log = await get_log_by_game_id(db, game_id, opponent_id)
     # 결과 기록
-    if result == "win":
-        user_log.result = MatchResult.WIN
-
-    elif result == "loss":
-        user_log.result = MatchResult.LOSS
-
-    elif result == "draw":
+    if not winner_id:
         user_log.result = MatchResult.DRAW
+        opponent_log.result = MatchResult.DRAW
+
+    elif winner_id == user_id:
+        user_log.result = MatchResult.WIN
+        opponent_log.result = MatchResult.LOSS
 
     else:
-        raise ValueError(f"Invalid result '{result}' passed to update_user_log.")
+        user_log.result = MatchResult.LOSS
+        opponent_log.result = MatchResult.WIN
+
     db.commit()
     db.refresh(user_log)
+    db.refresh(opponent_log)
 
-    return await update_user_mmr(db, game_id, user_id)
+    await update_user_mmr(db, game_id, user_id)
+    await update_user_mmr(db, game_id, opponent_id)
+    return
 
 
 async def update_match(db: Session, match_id: int, reason: str) -> None:

--- a/src/app/domain/game/service/game_service.py
+++ b/src/app/domain/game/service/game_service.py
@@ -4,7 +4,8 @@ import json
 from fastapi import HTTPException
 from src.app.config.config import settings
 from sqlalchemy.orm import Session
-from src.app.domain.game.service import game_result_service
+from src.app.domain.game.router.game_controller import process_match_result
+from src.app.domain.match.crud.match_crud import get_log_by_game_id
 
 
 async def evaluate_code(language: str, code: str):
@@ -67,10 +68,11 @@ async def stream_evaluate_code(db: Session, user_id: int, match_id: int, languag
                 # Parse the final message to extract the result
                 final_message = json.loads(message)
                 # Assuming 'result' is present in the final message from the judge service
-                result = final_message.get("result")
-
-                if result:
-                    await game_result_service.update_user_log(db, match_id, user_id, result)
+                result = final_message.get("status")
+                if result == "success":
+                    log = await get_log_by_game_id(db, match_id, user_id)
+                    opponent_id = log.opponent_id
+                    await process_match_result(db, match_id, user_id, opponent_id, "finish")
                 break
 
 async def stream_evaluate_code_public(language: str, code: str, problem_id: str):


### PR DESCRIPTION
game_controller.py
 -match_result 타입 메세지 수신 시, 핸들링하는 로직을 별개 함수로 분리
 -process_match_result()와 update_user_log()를 변경된 승패 정책대로 수정

gam_service.py
 -submit 후, succes 반환 시, process_match_result()로 유도 