### PR TITLE
🔨  [UPDATE] 문제 저장 시 이미지 업로드 방식 개선

### DIFF
--- a/src/app/domain/problem/service/problem_service.py
+++ b/src/app/domain/problem/service/problem_service.py
@@ -50,14 +50,14 @@ async def save_problem(
         upload_bytes(json_bytes, body_key, bucket=settings.PROBLEM_BUCKET)
 
         if images:
-            uploaded_image_urls = []
+            uploaded_image_keys = []
             for img in images:
                 file_bytes = await img.read()
                 # Use the full filename as part of the S3 key, as frontend will send it in the correct format
                 key = f"problems/{problem_uuid}/images/{img.filename}"
-                s3_url = await upload_image_to_s3_and_get_url(file_bytes, key, settings.PROBLEM_BUCKET)
-                uploaded_image_urls.append(s3_url)
-            image_keys = uploaded_image_urls
+                await upload_image_to_s3_and_get_url(file_bytes, key, settings.PROBLEM_BUCKET)
+                uploaded_image_keys.append(key)
+            image_keys = uploaded_image_keys
 
     new_problem = Problem(
         title=problem_data.title,


### PR DESCRIPTION
- 이미지 업로드 후 S3의 공개 URL 대신 파일 키를 저장하도록 변경하였습니다.
- 이미지 파일명을 유지하여 S3에 업로드하는 로직을 개선하였습니다.
<img width="1194" height="1114" alt="스크린샷 2025-07-12 오전 10 57 05" src="https://github.com/user-attachments/assets/0b645a30-8348-4d07-b642-6c4b15d809f8" />

