### PR TITLE
:hammer: [UPDATE] GitHub OAuth 로그인 후 프론트엔드로 리디렉션 처리 추가

### DIFF
--- a/.aws/ecs-task-definition.json
+++ b/.aws/ecs-task-definition.json
@@ -32,7 +32,7 @@
                 },
                 {
                     "name": "FRONTEND_REDIRECT_URL",
-                    "value": "https://code-ground.com"
+                    "value": "https://code-ground.com/oauth/callback"
                 },
                 {
                     "name": "ONLINE_JUDGE_HOST_ENDPOINT",
@@ -47,7 +47,7 @@
                     "value": "codeground-profile"
                 },
                 {
-                    "name": "GITHUB_REDIRECT_URI",
+                    "name": "GITHUB_REDIRECT_URL",
                     "value": "https://api.code-ground.com/api/v1/auth/github/callback"
                 }
             ],

--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     GITHUB_CLIENT_SECRET: str = os.environ.get("GITHUB_CLIENT_SECRET", "")
     REPORT_BUCKET: str = os.environ.get("REPORT_BUCKET", "")
     PROFILE_IMAGE_BUCKET: str = os.environ.get("PROFILE_IMAGE_BUCKET", "")
-    github_redirect_uri: str
+    GITHUB_REDIRECT_URL: str
 
     class Config:
         env_file = ENV_PATH

--- a/src/app/domain/auth/router/github_controller.py
+++ b/src/app/domain/auth/router/github_controller.py
@@ -28,10 +28,15 @@ async def github_callback(code: str, db: DB):
         return result  # 이메일 중복 등은 여전히 Redirect로 처리
 
     user, is_new_user = result
-    access_token = create_access_token(subject=user.email)  # ✅ user.email → user.user_id
+    access_token = create_access_token(subject=user.email)
 
-    response = JSONResponse(content={"message": "Login successful", "is_new_user": is_new_user})
+    # ✅ 프론트엔드로 리디렉션
+    response = RedirectResponse(
+        url=f"{settings.FRONTEND_REDIRECT_URL}?is_new_user={str(is_new_user).lower()}",
+        status_code=302
+    )
 
+    # ✅ 쿠키 설정
     secure, samesite, domain, http_only = get_cookie_options()
     response.set_cookie(
         key="access_token",


### PR DESCRIPTION
- 로그인 성공 시 JSON 응답 대신 RedirectResponse로 /oauth/callback 페이지 이동

- GITHUB_REDIRECT_URI -> GITHUB_REDIRECT_URL로 변경

- FRONTEND_REDIRECT_URL : https://code-ground.com -> https://code-ground.com/oauth/callback로 변경