### PR TITLE
♻️ [REFACTOR] 어떤 매치의 문제 ID를 해당 매치로부터 불러오기

### DIFF
--- a/src/app/domain/game/router/submit_controller.py
+++ b/src/app/domain/game/router/submit_controller.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import Session
 from src.app.core.database import get_db
 from src.app.core.security import get_current_user
 from src.app.models.models import User
+from src.app.domain.match.crud.match_crud import get_problem_id_from_match_id
+from src.app.utils.logging import logger
 
 router = APIRouter()
 
@@ -17,17 +19,27 @@ async def submit_code(request: schemas.SubmitRequest, db: Session = Depends(get_
     """
     AppStatus.should_exit_event = None # 여기서 AppStatus는, EventSourceResponse와 관련된 이벤트 스트리밍 처리에서, 서버 상태나 종료 신호(should_exit_event 등)를 관리하는 데 쓰임.
     # 코드에서 위 값(should_exit_event)을 명시적으로 None으로 리셋하는 이유는, 이전에 남아있던 종료 플래그를 초기화함으로써 새로운 SSE 세션에 영향이 없도록 하기 위함임.
-    event_generator = service.stream_evaluate_code(db, current_user.user_id, request.match_id, request.language, request.code, request.problem_id)
-    print(event_generator)
+
+    # match_crud.py로부터 problem_id를 가져옴.
+    event_generator = service.stream_evaluate_code(db, current_user.user_id, request.match_id, request.language, request.code, get_problem_id_from_match_id(db, request.match_id))
+    
+    logger.info(f"POST /submit - {event_generator}")
     return EventSourceResponse(event_generator)
 
 @router.post("/submit_public")
-async def submit_code_public(request: schemas.SubmitRequest):
+async def submit_code_public(
+    request: schemas.SubmitRequest,
+    db: Session = Depends(get_db)
+):
     """
     visiblity가 public인 테스트케이스들에 대하여 채점.
     """
+    
+    # match_crud.py로부터 problem_id를 가져옴.
     AppStatus.should_exit_event = None
     event_generator = service.stream_evaluate_code_public(
-        request.language, request.code, request.problem_id
+        request.language, request.code, get_problem_id_from_match_id(db, request.match_id)
     )
+
+    logger.info(f"POST /submit_public - {event_generator}")
     return EventSourceResponse(event_generator)

--- a/src/app/domain/match/crud/match_crud.py
+++ b/src/app/domain/match/crud/match_crud.py
@@ -61,3 +61,12 @@ async def get_match_log_by_user_index(db: Session, user_id: int, index: int) -> 
     stmt = (select(MatchLog).where(MatchLog.user_id == user_id).order_by(MatchLog.created_at.desc()).offset(start).limit(LOGS_PER_CLICK))
     result = db.execute(stmt)
     return result.scalars().all()
+
+
+def get_problem_id_from_match_id(db: Session, match_id: int) -> str:
+    # match_id로부터 문제 ID를 가져오는 함수
+    # `match` 테이블의 `problem_id` 컬럼을 사용하여 문제 ID를 조회
+    match = db.query(Match).filter(Match.match_id == match_id).first()
+    if match is None:
+        raise ValueError(f"No match found with ID {match_id}")
+    return str(match.problem_id)


### PR DESCRIPTION
- 프론트엔드에서 채점 실행/제출 시 `problem_id`가 `undefined`인 채 백엔드에 요청되고 있었습니다.
- 프론트엔드는 그냥 두고, 백엔드는 이제 채점 실행/제출 시 `match_id`로부터 `match` 테이블에서 `problem_id`를 가져와 실행/제출합니다.