### PR TITLE
♻️ [REFACTOR] 문제를 body_key로부터 fetch

### DIFF
--- a/src/app/domain/game/router/submit_controller.py
+++ b/src/app/domain/game/router/submit_controller.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from src.app.core.database import get_db
 from src.app.core.security import get_current_user
 from src.app.models.models import User
-from src.app.domain.match.crud.match_crud import get_problem_id_from_match_id
+from src.app.domain.match.crud.match_crud import get_body_key_from_match_id
 from src.app.utils.logging import logger
 
 router = APIRouter()
@@ -21,7 +21,12 @@ async def submit_code(request: schemas.SubmitRequest, db: Session = Depends(get_
     # 코드에서 위 값(should_exit_event)을 명시적으로 None으로 리셋하는 이유는, 이전에 남아있던 종료 플래그를 초기화함으로써 새로운 SSE 세션에 영향이 없도록 하기 위함임.
 
     # match_crud.py로부터 problem_id를 가져옴.
-    event_generator = service.stream_evaluate_code(db, current_user.user_id, request.match_id, request.language, request.code, get_problem_id_from_match_id(db, request.match_id))
+    event_generator = service.stream_evaluate_code(db, 
+                                                   current_user.user_id, 
+                                                   request.match_id, 
+                                                   request.language, 
+                                                   request.code, 
+                                                   get_body_key_from_match_id(db, request.match_id))
     
     logger.info(f"POST /submit - {event_generator}")
     return EventSourceResponse(event_generator)
@@ -38,7 +43,7 @@ async def submit_code_public(
     # match_crud.py로부터 problem_id를 가져옴.
     AppStatus.should_exit_event = None
     event_generator = service.stream_evaluate_code_public(
-        request.language, request.code, get_problem_id_from_match_id(db, request.match_id)
+        request.language, request.code, get_body_key_from_match_id(db, request.match_id)
     )
 
     logger.info(f"POST /submit_public - {event_generator}")

--- a/src/app/domain/match/crud/match_crud.py
+++ b/src/app/domain/match/crud/match_crud.py
@@ -1,7 +1,7 @@
 from src.app.models.models import MatchLog
 from typing import Optional, Sequence
 from sqlalchemy.orm import Session
-from src.app.models.models import Match, UserMmr
+from src.app.models.models import Match, UserMmr, Problem
 from sqlalchemy import select
 
 LOGS_PER_CLICK = 15
@@ -55,18 +55,19 @@ async def create_match_logs(db: Session, match_id: int, user_ids: list[int], pro
     db.commit()
     return
 
-
 async def get_match_log_by_user_index(db: Session, user_id: int, index: int) -> Sequence[MatchLog]:
     start = index * LOGS_PER_CLICK
     stmt = (select(MatchLog).where(MatchLog.user_id == user_id).order_by(MatchLog.created_at.desc()).offset(start).limit(LOGS_PER_CLICK))
     result = db.execute(stmt)
     return result.scalars().all()
 
-
-def get_problem_id_from_match_id(db: Session, match_id: int) -> str:
-    # match_id로부터 문제 ID를 가져오는 함수
-    # `match` 테이블의 `problem_id` 컬럼을 사용하여 문제 ID를 조회
+def get_body_key_from_match_id(db: Session, match_id: int) -> str:
+    # match_id로부터 body_key를 가져오는 함수
+    # match 테이블에서 problem_id를 얻고, problem 테이블에서 body_key를 조회
     match = db.query(Match).filter(Match.match_id == match_id).first()
     if match is None:
         raise ValueError(f"No match found with ID {match_id}")
-    return str(match.problem_id)
+    problem = db.query(Problem).filter(Problem.problem_id == match.problem_id).first()
+    if problem is None:
+        raise ValueError(f"No problem found with ID {match.problem_id}")
+    return getattr(problem, "body_key")


### PR DESCRIPTION
<img width="1081" height="413" alt="image" src="https://github.com/user-attachments/assets/bd127352-ffc8-423e-824f-dd88b97a8fe0" />

- 지금까지는 problem 테이블의 PK를 그대로 `.json`의 파일명으로 가져왔으나,
- 이제는 problem 테이블의 body_key를 그대로 S3에서 fetch할 파일명으로 씁니다.

즉, match 테이블의 match_id, problem_id **==>** problem 테이블의 problem_id, body_key **==>** S3로부터 해당 body_key를 사용하여 fetch합니다.