### PR TITLE
:bug: [FEAT] 프로필 이미지 업로드 기능 리팩토링

### DIFF
--- a/src/app/domain/user/service/user_service.py
+++ b/src/app/domain/user/service/user_service.py
@@ -60,7 +60,7 @@ async def update_my_profile(
         unique_filename = f"{uuid.uuid4()}-{profile_image.filename}"
         s3_key = f"profile_images/{unique_filename}"
         try:
-            s3.put_object(Bucket=PROFILE_IMAGE_BUCKET, Key=s3_key, Body=contents, ACL="public-read")  # ✅ 직접 업로드
+            s3.put_object(Bucket=PROFILE_IMAGE_BUCKET, Key=s3_key, Body=contents)  # ✅ 직접 업로드
             user.profile_img_url = s3_key
             logger.info(f"Profile image uploaded to {s3_key} for user ID: {user_id}")
         except Exception as e:

--- a/src/app/utils/s3_utils.py
+++ b/src/app/utils/s3_utils.py
@@ -54,7 +54,7 @@ def get_s3_public_url(bucket: str, key: str) -> str:
 async def upload_image_to_s3_and_get_url(file_bytes: bytes, key: str, bucket: str) -> str:
     """Uploads image bytes to S3 and returns its public URL."""
     try:
-        s3.put_object(Bucket=bucket, Key=key, Body=file_bytes, ACL="public-read")
+        s3.put_object(Bucket=bucket, Key=key, Body=file_bytes)
         return get_s3_public_url(bucket, key)
     except Exception as e:
         raise RuntimeError(f"Failed to upload image to S3: {e}")


### PR DESCRIPTION
- s3_utils.py , user_service.py 에서 ACL='public-read' 부분 삭제

S3 버킷이 "ACL(Access Control List)을 지원하지 않는 상태"로 설정되어 있는데, 업로드 코드에서 put_object 호출 시 ACL 파라미터를 사용하고 있어서 실패