### PR TITLE
:sparkles: [FEAT] Admin 사용자 관리 개선 및 데이터 모델 확장

### DIFF
--- a/src/app/domain/admin/crud/admin_crud.py
+++ b/src/app/domain/admin/crud/admin_crud.py
@@ -16,13 +16,19 @@ def ban_user(db: Session, user_id: int):
         db.refresh(user)
     return user
 
-# 2-1. 정지 해제(관리자 기능 필요시)
+# 2-1. 정지 해제 + 신고 카운트 초기화
 def unban_user(db: Session, user_id: int):
     user = db.query(User).filter(User.user_id == user_id).first()
     if user and user.is_banned:
         user.is_banned = False
         db.commit()
         db.refresh(user)
+        # 신고 무효화 (is_approved=True였던 걸 모두 False로 바꿈)
+        db.query(CheatReport).filter(
+            CheatReport.reported_user_id == user_id,
+            CheatReport.is_approved == True
+        ).update({"is_approved": False})
+        db.commit()
     return user
 
 
@@ -88,7 +94,7 @@ def get_user_match_history(db: Session, user_id: int):
 def get_all_match_logs(db: Session):
     return db.query(MatchLog).all()
 
-# 11. [중요] 자동 영구 정지: 승인된 신고가 3초과일 때 is_banned 처리
+# 11. 자동 영구 정지: 승인된 신고가 3초과일 때 is_banned 처리
 def auto_ban_user_if_needed(db: Session, user_id: int, threshold: int = 3):
     count = db.query(CheatReport).filter(
         CheatReport.reported_user_id == user_id,
@@ -101,3 +107,26 @@ def auto_ban_user_if_needed(db: Session, user_id: int, threshold: int = 3):
         db.refresh(user)
         return True
     return False
+
+# 12. 전체 유저 + 각 유저별 신고당한 횟수(report_count) 조회
+def get_all_users_with_report_count(db: Session):
+    from sqlalchemy.sql import func
+
+    subq = (
+        db.query(
+            CheatReport.reported_user_id.label("user_id"),
+            func.count(CheatReport.report_id).label("report_count")
+        )
+        .group_by(CheatReport.reported_user_id)
+        .subquery()
+    )
+
+    result = (
+        db.query(
+            User,
+            func.coalesce(subq.c.report_count, 0).label("report_count")
+        )
+        .outerjoin(subq, User.user_id == subq.c.user_id)
+        .all()
+    )
+    return result

--- a/src/app/domain/admin/router/admin_controller.py
+++ b/src/app/domain/admin/router/admin_controller.py
@@ -21,8 +21,18 @@ router = APIRouter(
 # (1) 전체 유저 목록을 조회하는 엔드포인트
 @router.get("/users", response_model=List[AdminUserOut])
 def get_all_users(db: Session = Depends(get_db)):
-    users = admin_crud.get_all_users(db)
-    return users  # orm_mode=True이므로 객체 반환만으로 자동 직렬화
+    users_with_reports = admin_crud.get_all_users_with_report_count(db)
+    result = []
+    for user, report_count in users_with_reports:
+        result.append({
+            "user_id": user.user_id,
+            "email": user.email,
+            "nickname": user.nickname,
+            "is_banned": user.is_banned,
+            "report_count": report_count,
+            "created_at": user.created_at,
+        })
+    return result
 
 # (2) 특정 유저를 영구정지 처리하는 엔드포인트
 @router.post("/users/{user_id}/ban", response_model=AdminUserBanResult)

--- a/src/app/domain/admin/schemas/admin_schemas.py
+++ b/src/app/domain/admin/schemas/admin_schemas.py
@@ -8,7 +8,7 @@ class AdminUserOut(BaseModel):
     email: str
     nickname: str
     is_banned: bool
-    role: str
+    report_count: int
     created_at: datetime
 
     class Config:
@@ -20,7 +20,6 @@ class AdminReportOut(BaseModel):
     reported_user_id: int
     reason: str
     description: Optional[str]
-    is_confirmed: bool
     created_at: datetime
 
     class Config:
@@ -53,7 +52,6 @@ class AdminUserBanResult(BaseModel):
 # 6. 신고 승인 결과
 class AdminReportConfirmResult(BaseModel):
     report_id: int
-    is_confirmed: bool
 
 # 7. 문제 승인 결과
 class AdminProblemApproveResult(BaseModel):

--- a/src/app/domain/admin/schemas/admin_schemas.py
+++ b/src/app/domain/admin/schemas/admin_schemas.py
@@ -20,6 +20,7 @@ class AdminReportOut(BaseModel):
     reported_user_id: int
     reason: str
     description: Optional[str]
+    is_approved: Optional[bool]
     created_at: datetime
 
     class Config:

--- a/src/app/models/models.py
+++ b/src/app/models/models.py
@@ -174,5 +174,5 @@ class CheatReport(Base):
     description = Column(Text, nullable=True)
     video_path = Column(Text, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    # 신고 당한 사람 O, 신고를 한 사람 X
-    reported_user_id = Column(Integer, ForeignKey("users.user_id"), nullable=False)
+    reported_user_id = Column(Integer, ForeignKey("users.user_id"), nullable=False)     # 신고 당한 사람 O, 신고를 한 사람 X
+    is_approved = Column(Boolean, nullable=True)    # 관리자가 승인 O -> True, X -> False, 대기중 -> Null


### PR DESCRIPTION
- 모든 사용자와 신고 횟수 조회 기능(`get_all_users_with_report_count`) 추가
- 사용자 정지 해제 시 신고 승인 상태 초기화 기능 추가 (`unban_user`)
- `CheatReport` 모델에 `is_approved` 필드 추가 (신고 승인 상태 저장)
- `AdminUserOut` 스키마에 `report_count` 필드 추가
- API 응답 직렬화 로직 및 데이터 모델 업데이트