### PR TITLE
:bug: [FEAT] 프로필 이미지가 새로고침, 로그아웃 해도 남이있게 수정

### DIFF
--- a/src/app/domain/user/router/user_controller.py
+++ b/src/app/domain/user/router/user_controller.py
@@ -82,7 +82,7 @@ async def update_my_profile_handler(
 
     return schemas.UserUpdateResponse(
         message="회원 정보가 성공적으로 수정되었습니다.",
-        user=schemas.UserResponseDto(**user_dict),
+        user=schemas.UserResponseDto.model_validate(user_dict),
     )
 
 


### PR DESCRIPTION
 S3 key만 내려오고 있고, full URL이 아님.

✅ 결론: UserResponseDto 쪽 @model_validator 로직이 적용 안 되고 있었음

- user_controller.py : schemas.UserResponseDto.model_validate(...)를 사용하면 @model_validator가 동작해서 이미지 URL이 자동으로 풀 URL로 변환