### PR TITLE
:seedling: [FEAT] 로그인 로직 개선: 정지 계정 처리 추가

### DIFF
--- a/src/app/domain/auth/router/auth_controller.py
+++ b/src/app/domain/auth/router/auth_controller.py
@@ -89,6 +89,12 @@ async def login(
     logger.info(f"Logging in user: {form_data.username}")
     try:
         user = await service.authenticate_user(db, form_data.username, form_data.password)
+
+        # 정지 계정 처리 추가 -> is_banned = True
+        if user.is_banned:
+            logger.warning(f"Banned user attempted login: {user.email}")
+            raise HTTPException(status_code=403, detail="유저는 현재 정지 상태입니다.")
+
         access_token = create_access_token(subject=user.email)
 
         # 환경에 따라 쿠키 옵션 분기 (가독성 및 실수 방지)

--- a/src/app/domain/auth/schemas/auth_schemas.py
+++ b/src/app/domain/auth/schemas/auth_schemas.py
@@ -31,6 +31,7 @@ class LoginUserDto(BaseModel):
     email: str
     username: str
     nickname: str
+    is_banned: bool
     last_login_at: Optional[datetime] = None
     consecutive_login_days: int
 


### PR DESCRIPTION
- 로그인 시 정지된 사용자(`is_banned=True`)에 대한 접근 차단 및 예외 처리 로직 추가
- 정지된 사용자가 로그인 시도 시 경고 메시지 로깅