### PR TITLE
✨ [FEAT] 업적 시스템 개선: 선행 업적 기능 추가 및 신고 횟수 업적 구현

### DIFF
--- a/ACHIEVEMENT_GUIDE_FRONTEND.md
+++ b/ACHIEVEMENT_GUIDE_FRONTEND.md
@@ -24,7 +24,7 @@
 
 ### 3.1. 유저용 API
 
-유저의 업적 정보를 가져오는 API입니다. 게임 종료 후 또는 유저의 업적 페이지에 진입했을 때 호출하여 최신 상태를 반영할 수 있습니다.
+유저의 업적 정보를 가져오는 API입니다. **로그인 관련 업적(연속 로그인, 요일별 로그인)은 `GET /api/v1/users/me` API 호출 시점에 체크됩니다.** 게임 종료 후 또는 유저의 업적 페이지에 진입했을 때 호출하여 최신 상태를 반영할 수 있습니다.
 
 -   **`GET /api/v1/achievements/users/{user_id}`**
     -   **설명**: 특정 유저가 획득한 모든 업적 목록을 조회합니다.
@@ -132,7 +132,7 @@
 관리자 페이지에서 업적을 관리(CRUD)하기 위한 API 엔드포인트입니다.
 
 -   **`POST /api/v1/admin/achievements`**
-    -   **설명**: 새로운 업적을 생성합니다.
+    -   **설명**: 새로운 업적을 생성합니다. **복합 업적을 생성하려면 `prerequisite_achievement_ids` 필드에 선행 업적 ID 목록을 포함합니다.**
     -   **요청 본문 (Request Body):**
         ```json
         {
@@ -141,7 +141,24 @@
           "trigger_type": "TOTAL_WIN",
           "parameter": 10,
           "reward_type": "BADGE",
-          "reward_amount": 1
+          "reward_amount": 1,
+          "prerequisite_achievement_ids": [] // 선택 사항: 이 업적을 달성하기 위한 선행 업적 ID 목록
+        }
+        ```
+    -   **복합 업적 예시 (Request Body):**
+        ```json
+        {
+          "title": "마스터 코더",
+          "description": "브론즈 승리 업적과 실버 문제 해결 업적을 모두 달성",
+          "achievement_category_id": 1,
+          "trigger_type": "TOTAL_WIN",
+          "parameter": 100,
+          "reward_type": "BADGE",
+          "reward_amount": 1,
+          "prerequisite_achievement_ids": [
+            101,  // "브론즈 승리 업적"의 ID (예시)
+            102   // "실버 문제 해결 업적"의 ID (예시)
+          ]
         }
         ```
 
@@ -208,6 +225,7 @@
 | `APPROVED_PROBLEM_COUNT`     | 유저가 등록한 문제가 관리자에 의해 승인된 횟수           | 목표 승인 횟수               |
 | `CONSECUTIVE_LOGIN`          | 연속 로그인 일수                                         | 목표 연속 로그인 일수        |
 | `LOGIN_ON_DAY_OF_WEEK`       | 특정 요일에 로그인                                       | 요일 (0=월요일, 6=일요일)    |
+| `TOTAL_REPORTS_MADE`         | 총 신고 횟수 (유저가 다른 유저를 신고한 횟수)            | 목표 신고 횟수               |
 
 ---
 

--- a/src/app/domain/achievement/crud/achievement_crud.py
+++ b/src/app/domain/achievement/crud/achievement_crud.py
@@ -9,7 +9,48 @@ from src.app.models.models import (
     UserAchievement,
     Problem,
     Match,
+    AchievementPrerequisite,
+    CheatReport,
 )
+from src.app.domain.achievement.schemas.achievement_schemas import AchievementCreate
+
+def get_total_reports_made(db: Session, user_id: int) -> int:
+    return (
+        db.query(func.count())
+        .select_from(CheatReport)
+        .filter(
+            CheatReport.reporter_user_id == user_id
+        )
+        .scalar()
+        or 0
+    )
+
+def create_achievement(db: Session, achievement_in: AchievementCreate) -> Achievement:
+    db_achievement = Achievement(
+        title=achievement_in.title,
+        description=achievement_in.description,
+        achievement_category_id=achievement_in.achievement_category_id,
+        trigger_type=achievement_in.trigger_type,
+        parameter=achievement_in.parameter,
+        reward_type=achievement_in.reward_type,
+        reward_amount=achievement_in.reward_amount,
+    )
+    db.add(db_achievement)
+    db.flush()  # Flush to get the achievement_id
+
+    if achievement_in.prerequisite_achievement_ids:
+        for prereq_id in achievement_in.prerequisite_achievement_ids:
+            db_prereq = AchievementPrerequisite(
+                achievement_id=db_achievement.achievement_id,
+                prerequisite_achievement_id=prereq_id,
+            )
+            db.add(db_prereq)
+
+    db.commit()
+    db.refresh(db_achievement)
+    return db_achievement
+
+
 
 
 def get_total_wins(db: Session, user_id: int) -> int:
@@ -171,3 +212,10 @@ def update_user_achievement_reward_status(
 
 def get_all_achievements(db: Session) -> list[Achievement]:
     return db.query(Achievement).all()
+
+def has_user_achieved(db: Session, user_id: int, achievement_id: int) -> bool:
+    return db.query(UserAchievement).filter(
+        UserAchievement.user_id == user_id,
+        UserAchievement.achievement_id == achievement_id,
+        UserAchievement.obtained_at.isnot(None) # 업적 달성 시각이 존재해야 함
+    ).first() is not None

--- a/src/app/domain/achievement/schemas/achievement_schemas.py
+++ b/src/app/domain/achievement/schemas/achievement_schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from datetime import datetime
+from typing import List, Optional
 from src.app.models.models import AchievementTriggerType, RewardType
 
 
@@ -16,6 +17,17 @@ class AchievementBase(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class AchievementCreate(BaseModel):
+    title: str
+    description: Optional[str] = None
+    achievement_category_id: Optional[int] = None
+    trigger_type: AchievementTriggerType
+    parameter: Optional[int] = None
+    reward_type: RewardType
+    reward_amount: int
+    prerequisite_achievement_ids: Optional[List[int]] = None
 
 
 class UserAchievementResponse(BaseModel):

--- a/src/app/domain/achievement/service/achievement_service.py
+++ b/src/app/domain/achievement/service/achievement_service.py
@@ -16,6 +16,23 @@ async def check_and_unlock_achievements(
         trigger_type,
     )
     for ach in achievements:
+        # 이미 달성한 업적은 건너뛰기
+        if achievement_crud.get_user_achievement(db, user_id, ach.achievement_id):
+            continue
+
+        # 선행 업적 확인
+        # ach.prerequisites는 AchievementPrerequisite 객체들의 리스트
+        # 각 객체는 prerequisite_achievement_id를 가짐
+        all_prerequisites_met = True
+        if ach.prerequisites: # 선행 업적이 정의되어 있다면
+            for prereq_entry in ach.prerequisites:
+                if not achievement_crud.has_user_achieved(db, user_id, prereq_entry.prerequisite_achievement_id):
+                    all_prerequisites_met = False
+                    break
+        
+        if not all_prerequisites_met:
+            continue # 선행 업적이 충족되지 않았으면 다음 업적으로
+
         if ach.parameter is not None:
             # "적을수록 좋은" 업적 (예: N번 안에 풀기, 빨리 풀기, 오답 없이 승리)
             if trigger_type in [
@@ -33,19 +50,13 @@ async def check_and_unlock_achievements(
                 condition = current_value >= ach.parameter
 
             if condition:
-                existing = achievement_crud.get_user_achievement(
+                ua = achievement_crud.create_user_achievement(
                     db,
                     user_id,
                     ach.achievement_id,
                 )
-                if not existing:
-                    ua = achievement_crud.create_user_achievement(
-                        db,
-                        user_id,
-                        ach.achievement_id,
-                    )
-                    ua.current_value = current_value
-                    ua.obtained_at = datetime.now(timezone.utc)
+                ua.current_value = current_value
+                ua.obtained_at = datetime.now(timezone.utc)
     db.commit()
 
 
@@ -87,6 +98,8 @@ async def handle_achievement_event(
         current_value = kwargs.get("current_value", 0)
     elif trigger_type == AchievementTriggerType.LOGIN_ON_DAY_OF_WEEK:
         current_value = kwargs.get("current_value", 0)
+    elif trigger_type == AchievementTriggerType.TOTAL_REPORTS_MADE:
+        current_value = achievement_crud.get_total_reports_made(db, user_id)
 
     if current_value > 0 or trigger_type == AchievementTriggerType.LOGIN_ON_DAY_OF_WEEK:
         await check_and_unlock_achievements(

--- a/src/app/domain/admin/crud/admin_crud.py
+++ b/src/app/domain/admin/crud/admin_crud.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 from src.app.models.models import User, CheatReport, Problem, MatchLog, UserMmr
-from src.app.models.models import Achievement, Match # Added Match
+from src.app.models.models import Achievement, Match, AchievementPrerequisite # Added Match, AchievementPrerequisite
 from src.app.domain.admin.schemas.admin_schemas import AchievementCreate, AchievementUpdate, AdminProblemUpdate # Added AdminProblemUpdate
 from src.app.utils.s3_utils import issue_problem_urls, upload_bytes # Added S3 utilities
 from typing import Optional, List, Dict # Added for type hints
@@ -250,7 +250,19 @@ def update_achievement(db: Session, achievement_id: int, achievement: Achievemen
     db_achievement = get_achievement(db, achievement_id)
     if db_achievement:
         for key, value in achievement.dict(exclude_unset=True).items():
-            setattr(db_achievement, key, value)
+            if key == "prerequisite_achievement_ids":
+                # 기존 선행 업적 관계 삭제
+                db.query(AchievementPrerequisite).filter(AchievementPrerequisite.achievement_id == achievement_id).delete()
+                if value:
+                    # 새로운 선행 업적 관계 추가
+                    for prereq_id in value:
+                        db_prereq = AchievementPrerequisite(
+                            achievement_id=achievement_id,
+                            prerequisite_achievement_id=prereq_id,
+                        )
+                        db.add(db_prereq)
+            else:
+                setattr(db_achievement, key, value)
         db.commit()
         db.refresh(db_achievement)
     return db_achievement

--- a/src/app/domain/admin/schemas/admin_schemas.py
+++ b/src/app/domain/admin/schemas/admin_schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, model_validator
-from typing import Optional
+from typing import Optional, List
 from datetime import datetime
 from src.app.models.models import AchievementTriggerType, RewardType
 
@@ -115,7 +115,7 @@ class AchievementCreate(AchievementBase):
 
 
 class AchievementUpdate(AchievementBase):
-    pass
+    prerequisite_achievement_ids: Optional[List[int]] = None
 
 
 class AchievementResponse(AchievementBase):

--- a/src/app/domain/auth/service/auth_service.py
+++ b/src/app/domain/auth/service/auth_service.py
@@ -71,34 +71,6 @@ async def authenticate_user(db: Session, email: str, password: str) -> schemas.L
 
     
 
-    # 로그인 정보 업데이트 및 업적 확인
-    today = datetime.now(timezone.utc).date()
-    last_login_date = user.last_login_at.date() if user.last_login_at else None
-
-    if last_login_date == today:
-        # 같은 날 재로그인 시 연속 로그인 유지
-        pass
-    elif last_login_date == today - timedelta(days=1):
-        # 어제 로그인했으면 연속 로그인 증가
-        user.consecutive_login_days += 1
-    else:
-        # 연속 로그인 끊김
-        user.consecutive_login_days = 1
-
-    user.last_login_at = datetime.now(timezone.utc)
-    crud.update_user_login_info(db, user, user.last_login_at, user.consecutive_login_days)
-
-    # 업적 확인
-    await achievement_service.handle_achievement_event(
-        db, user.user_id, AchievementTriggerType.CONSECUTIVE_LOGIN, current_value=user.consecutive_login_days
-    )
-    await achievement_service.handle_achievement_event(
-        db,
-        user.user_id,
-        AchievementTriggerType.LOGIN_ON_DAY_OF_WEEK,
-        current_value=datetime.now(timezone.utc).weekday(),  # 월요일=0, 일요일=6
-    )
-
     logger.info(f"User {email} authenticated successfully")
     return schemas.LoginUserDto.model_validate(user)
 

--- a/src/app/domain/match/crud/match_crud.py
+++ b/src/app/domain/match/crud/match_crud.py
@@ -76,3 +76,14 @@ def get_body_key_from_problem_id(db: Session, problem_id: int) -> str:
     if problem is None:
         raise ValueError(f"No problem found with ID {problem_id}")
     return getattr(problem, "body_key")
+
+
+def get_match_opponent_id(db: Session, match_id: int, reporter_user_id: int) -> Optional[int]:
+    # 주어진 match_id에서 reporter_user_id의 상대방 ID를 찾습니다.
+    match_log = db.query(MatchLog).filter(
+        MatchLog.match_id == match_id,
+        MatchLog.user_id == reporter_user_id
+    ).first()
+    if match_log:
+        return match_log.opponent_id
+    return None

--- a/src/app/domain/report/crud/report_crud.py
+++ b/src/app/domain/report/crud/report_crud.py
@@ -3,7 +3,7 @@ from src.app.models.models import CheatReport
 
 
 def create_report(
-    db: Session, game_id: int | None, reason: str, description: str, video_path: str, reported_user_id: int
+    db: Session, game_id: int | None, reason: str, description: str, video_path: str, reported_user_id: int, reporter_user_id: int
 ) -> CheatReport:
     report = CheatReport(
         game_id=game_id,
@@ -11,6 +11,7 @@ def create_report(
         description=description,
         video_path=video_path,
         reported_user_id=reported_user_id,
+        reporter_user_id=reporter_user_id,
     )
     db.add(report)
     db.commit()

--- a/src/app/domain/report/router/report_controller.py
+++ b/src/app/domain/report/router/report_controller.py
@@ -1,19 +1,28 @@
-from fastapi import APIRouter, Depends, UploadFile, File, Form
+from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException, status
 from sqlalchemy.orm import Session
 from src.app.core.database import get_db
 from src.app.domain.report.service import report_service as service
+from src.app.core.security import get_current_user
+from src.app.models.models import User
+from src.app.domain.match.crud import match_crud
 
 router = APIRouter()
 
 
 @router.post("/", status_code=201)
 async def create_report(
-    game_id: int | None = Form(None),
+    game_id: int = Form(...), # game_id는 match_id로 사용
     reason: str = Form(...),
     description: str = Form(...),
     video: UploadFile = File(...),
-    reported_user_id: int = Form(...),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
-    await service.save_report(db, game_id, reason, description, video, reported_user_id)
+    # match_id를 사용하여 reported_user_id를 찾습니다.
+    reported_user_id = match_crud.get_match_opponent_id(db, game_id, current_user.user_id)
+
+    if reported_user_id is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Reported user not found in this match.")
+
+    await service.save_report(db, game_id, reason, description, video, reported_user_id, current_user.user_id)
     return {"message": "Report received"}

--- a/src/app/domain/report/service/report_service.py
+++ b/src/app/domain/report/service/report_service.py
@@ -7,6 +7,8 @@ from fastapi import UploadFile
 from datetime import datetime
 
 from src.app.domain.report.crud import report_crud
+from src.app.domain.achievement.service import achievement_service
+from src.app.models.models import AchievementTriggerType
 
 ROOT_DIR = Path(__file__).resolve().parents[4]
 REPORT_DIR = ROOT_DIR / "resource" / "static" / "reports"
@@ -14,7 +16,7 @@ REPORT_DIR.mkdir(parents=True, exist_ok=True)
 
 
 async def save_report(
-    db: Session, game_id: int | None, reason: str, description: str, video: UploadFile, reported_user_id: int
+    db: Session, game_id: int | None, reason: str, description: str, video: UploadFile, reported_user_id: int, reporter_user_id: int
 ) -> None:
     file_name = f"{uuid.uuid4()}.webm"
     env = (getattr(settings, "ENV", None) or getattr(settings, "ENVIRONMENT", None) or "local").lower()
@@ -33,4 +35,11 @@ async def save_report(
         upload_bytes(file_bytes, s3_key, bucket=settings.REPORT_BUCKET)
         video_path = s3_key
 
-    report_crud.create_report(db, game_id, reason, description, video_path, reported_user_id)
+    report_crud.create_report(db, game_id, reason, description, video_path, reported_user_id, reporter_user_id)
+
+    # 업적 확인: 신고 횟수
+    await achievement_service.handle_achievement_event(
+        db,
+        reporter_user_id, # 신고를 한 유저의 ID
+        AchievementTriggerType.TOTAL_REPORTS_MADE,
+    )

--- a/src/app/domain/user/crud/user_crud.py
+++ b/src/app/domain/user/crud/user_crud.py
@@ -34,3 +34,11 @@ def delete_user(db: Session, user_id: int) -> bool:
 def get_user_mmr(db: Session, user_id: int) -> int:
     mmr_obj = db.query(UserMmr).filter(UserMmr.user_id == user_id).first()
     return mmr_obj.rating if mmr_obj else 1000
+
+def update_user_login_info(db: Session, user: User, last_login_at, consecutive_login_days):
+    user.last_login_at = last_login_at
+    user.consecutive_login_days = consecutive_login_days
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user

--- a/src/app/domain/user/service/user_service.py
+++ b/src/app/domain/user/service/user_service.py
@@ -8,6 +8,9 @@ from src.app.utils.s3_utils import PROFILE_IMAGE_BUCKET, s3
 from src.app.models.models import UserMmr
 from src.app.domain.match.crud.match_crud import get_mmr_by_id
 import uuid
+from datetime import datetime, timedelta, timezone
+from src.app.domain.achievement.service import achievement_service
+from src.app.models.models import AchievementTriggerType
 
 
 async def get_user_data(db: Session, input_id: int) -> schemas.UserDto:
@@ -16,6 +19,35 @@ async def get_user_data(db: Session, input_id: int) -> schemas.UserDto:
     if not user:
         logger.warning(f"User with ID {input_id} not found.")
         raise HTTPException(status_code=404, detail="User not found")
+
+    # 로그인 정보 업데이트 및 업적 확인
+    today = datetime.now(timezone.utc).date()
+    last_login_date = user.last_login_at.date() if user.last_login_at else None
+
+    if last_login_date == today:
+        # 같은 날 재로그인 시 연속 로그인 유지
+        pass
+    elif last_login_date == today - timedelta(days=1):
+        # 어제 로그인했으면 연속 로그인 증가
+        user.consecutive_login_days += 1
+    else:
+        # 연속 로그인 끊김
+        user.consecutive_login_days = 1
+
+    user.last_login_at = datetime.now(timezone.utc)
+    crud.update_user_login_info(db, user, user.last_login_at, user.consecutive_login_days)
+
+    # 업적 확인
+    await achievement_service.handle_achievement_event(
+        db, user.user_id, AchievementTriggerType.CONSECUTIVE_LOGIN, current_value=user.consecutive_login_days
+    )
+    await achievement_service.handle_achievement_event(
+        db,
+        user.user_id,
+        AchievementTriggerType.LOGIN_ON_DAY_OF_WEEK,
+        current_value=datetime.now(timezone.utc).weekday(),  # 월요일=0, 일요일=6
+    )
+
     logger.info(f"Successfully retrieved user data for ID: {input_id}")
     return schemas.UserDto.model_validate(user)
 

--- a/src/app/models/models.py
+++ b/src/app/models/models.py
@@ -183,6 +183,7 @@ class CheatReport(Base):
     video_path = Column(Text, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     reported_user_id = Column(Integer, ForeignKey("users.user_id"), nullable=False)     # 신고 당한 사람 O, 신고를 한 사람 X
+    reporter_user_id = Column(Integer, ForeignKey("users.user_id"), nullable=False)     # 신고를 한 사람 O
     is_approved = Column(Boolean, nullable=True)    # 관리자가 승인 O -> True, X -> False, 대기중 -> Null
 
 
@@ -234,6 +235,7 @@ class AchievementTriggerType(str, PyEnum):
     APPROVED_PROBLEM_COUNT = "approved_problem_count"
     CONSECUTIVE_LOGIN = "consecutive_login"
     LOGIN_ON_DAY_OF_WEEK = "login_on_day_of_week"
+    TOTAL_REPORTS_MADE = "total_reports_made"
 
 
 # ———————————————— 업적 카테고리 ————————————————
@@ -261,9 +263,7 @@ class Achievement(Base):
     achievement_category_id = Column(Integer, ForeignKey("achievement_category.achievement_category_id"), nullable=True)
     category = relationship("AchievementCategory", back_populates="achievements")
 
-    # — 누적형 업적 체인(자기 참조) —
-    next_achievement_id = Column(Integer, ForeignKey("achievement.achievement_id"), nullable=True)
-    next_achievement = relationship("Achievement", remote_side=[achievement_id], backref="previous_achievement")
+    
 
     # — 보상 정보 —
     reward_type = Column(Enum(RewardType), nullable=False, server_default=RewardType.BADGE.value)
@@ -285,3 +285,37 @@ class Achievement(Base):
 
     # 관계: 사용자별 업적
     user_achievements = relationship("UserAchievement", back_populates="achievement")
+
+    # 관계: 이 업적을 달성하기 위한 선행 업적들
+    prerequisites = relationship(
+        "AchievementPrerequisite",
+        foreign_keys="[AchievementPrerequisite.achievement_id]",
+        back_populates="achievement",
+        cascade="all, delete-orphan"
+    )
+    # 관계: 이 업적이 선행 업적으로 사용되는 다른 업적들
+    is_prerequisite_for = relationship(
+        "AchievementPrerequisite",
+        foreign_keys="[AchievementPrerequisite.prerequisite_achievement_id]",
+        back_populates="prerequisite_achievement",
+        cascade="all, delete-orphan"
+    )
+
+
+class AchievementPrerequisite(Base):
+    __tablename__ = "achievement_prerequisite"
+
+    achievement_id = Column(Integer, ForeignKey("achievement.achievement_id"), primary_key=True)
+    prerequisite_achievement_id = Column(Integer, ForeignKey("achievement.achievement_id"), primary_key=True)
+
+    # 관계
+    achievement = relationship(
+        "Achievement",
+        foreign_keys=[achievement_id],
+        back_populates="prerequisites"
+    )
+    prerequisite_achievement = relationship(
+        "Achievement",
+        foreign_keys=[prerequisite_achievement_id],
+        back_populates="is_prerequisite_for"
+    )


### PR DESCRIPTION
- 유저의 업적 생성 시 선행 업적 ID 목록을 포함할 수 있는 기능 추가
- 신고 횟수에 대한 업적 체크 로직 구현
- 관련 API 및 스키마 업데이트
- 문서에 로그인 관련 업적 체크 설명 추가