### PR TITLE
:recycle: [FEAT] 랭킹 페이지, 화면 공유 페이지에 프로필 이미지 추가

### DIFF
--- a/src/app/domain/match/service/match_service.py
+++ b/src/app/domain/match/service/match_service.py
@@ -14,6 +14,7 @@ from src.app.domain.match.schemas.match_schemas import MatchLogSchema
 from src.app.domain.game.crud.game_crud import get_problem_by_id
 from src.app.utils.logging import logger
 from itertools import count
+from src.app.utils.s3_utils import get_s3_public_url, PROFILE_IMAGE_BUCKET
 
 # 매칭 루프 타이머
 MATCH_INTERVAL = 1  # 초 세팅 0.5 = 500ms
@@ -102,7 +103,6 @@ class MatchService:
                 logger.info("Match service task cancelled successfully.")
             except asyncio.CancelledError:
                 logger.warning("Match service task was already cancelled.")
-                pass
 
 
 # 매칭된 사용자 쌍에게 매칭 완료 메시지 전송
@@ -120,7 +120,7 @@ async def dispatch_pairs(db: Session, pairs, algo):
             u2.id: False,
         }
 
-        # 각 사용자의 상세 정보 (닉네임, MMR) 조회
+        # 각 사용자의 상세 정보 (닉네임, MMR, 프로필 이미지) 조회
         user1_data = get_user_by_id(db, u1.id)
         user2_data = get_user_by_id(db, u2.id)
 
@@ -131,16 +131,30 @@ async def dispatch_pairs(db: Session, pairs, algo):
         user1_tier = mmr_to_tier(user1_mmr)
         user2_tier = mmr_to_tier(user2_mmr)
 
+        # 프로필 이미지 URL 생성
+        user1_profile_url = (
+            get_s3_public_url(PROFILE_IMAGE_BUCKET, user1_data.profile_img_url)
+            if user1_data.profile_img_url and not user1_data.profile_img_url.startswith("http")
+            else user1_data.profile_img_url
+        )
+        user2_profile_url = (
+            get_s3_public_url(PROFILE_IMAGE_BUCKET, user2_data.profile_img_url)
+            if user2_data.profile_img_url and not user2_data.profile_img_url.startswith("http")
+            else user2_data.profile_img_url
+        )
+
         # 각 사용자에게 전송할 상대방 정보 구성
         opponent1_info = {
             "id": user2_data.user_id,
             "nickname": user2_data.nickname,
             "tier": user2_tier,
+            "profile_img_url": user2_profile_url,  # 프로필 이미지 URL 추가
         }
         opponent2_info = {
             "id": user1_data.user_id,
             "nickname": user1_data.nickname,
             "tier": user1_tier,
+            "profile_img_url": user1_profile_url,  # 프로필 이미지 URL 추가
         }
 
         # u1에게 u2의 정보를 포함하여 매칭 완료 메시지 전송

--- a/src/app/domain/ranking/schemas/ranking_schemas.py
+++ b/src/app/domain/ranking/schemas/ranking_schemas.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 class RankingEntry(BaseModel):
     user_id: int
     nickname: str
+    profile_img_url: Optional[str] = None
     mmr: int
     rank: int
     rank_diff: Optional[int] = 0

--- a/src/app/domain/ranking/service/ranking_service.py
+++ b/src/app/domain/ranking/service/ranking_service.py
@@ -5,6 +5,7 @@ from src.app.domain.ranking.crud import ranking_crud as crud
 from src.app.domain.ranking.schemas import ranking_schemas as schemas
 from src.app.domain.user.crud.user_crud import get_user_by_id
 from src.app.models.models import UserMmr, Ranking
+from src.app.utils.s3_utils import get_s3_public_url, PROFILE_IMAGE_BUCKET
 from src.app.utils.tier_util import mmr_to_tier, tiers_cnt, tiers
 
 
@@ -16,6 +17,11 @@ async def get_language_ranking(db: Session, language: str) -> schemas.RankingLis
         schemas.RankingEntry(
             user_id=ranking.user_id,
             nickname=ranking.user.nickname,
+            profile_img_url=(
+                get_s3_public_url(PROFILE_IMAGE_BUCKET, ranking.user.profile_img_url)
+                if ranking.user.profile_img_url and not ranking.user.profile_img_url.startswith("http")
+                else ranking.user.profile_img_url
+            ),
             mmr=ranking.mmr,
             rank=ranking.rank,
             rank_diff=ranking.rank_diff or 0,


### PR DESCRIPTION
ranking_schemas.py : 랭킹 페이지에 사용자 프로필 이미지를 표시하기 위해, 랭킹 데이터 스키마에 profile_img_url 필드를 추가

ranking_service.py : 랭킹 데이터를 조회할 때, 각 사용자의 프로필 이미지 URL을 가져와 전체 S3 URL로 변환하여 스키마에 맞게 포함

match_service.py : 게임 매칭 후 화면 공유 준비 페이지에서 상대방 프로필 이미지를 표시하기 위해, 매칭 완료 메시지에 profile_img_url을 포함